### PR TITLE
Feature/r type test

### DIFF
--- a/how_to_test.txt
+++ b/how_to_test.txt
@@ -6,3 +6,8 @@ testディレクトリの運用方法
 　
 例:
 make test TARGET=jalr
+
+testコード一覧
+・jalr
+・i-type
+・r-type

--- a/pipeline/alu.sv
+++ b/pipeline/alu.sv
@@ -15,7 +15,7 @@ always_comb begin
         3'b001 : alu_result = srca - srcb;
         3'b010 : alu_result = srca & srcb;
         3'b011 : alu_result = srca | srcb;
-        3'b101 : alu_result = srca < srcb;
+        3'b101 : alu_result = $signed(srca) < $signed(srcb);
         default: begin
             alu_result = 32'hDEADBEEF;
             $display("Unknown ALU command.");

--- a/pipeline/cpu.sv
+++ b/pipeline/cpu.sv
@@ -293,7 +293,7 @@ module CPU(
 
     ALU alu(
         .alu_control(alu_control_e),
-        .srca(rd1_e),
+        .srca(pc_alu_src_a_e),
         .srcb(srcb_e),
         .alu_result(alu_result_e),
         .zero(zero_e)

--- a/pipeline/cpu.sv
+++ b/pipeline/cpu.sv
@@ -293,7 +293,7 @@ module CPU(
 
     ALU alu(
         .alu_control(alu_control_e),
-        .srca(pc_alu_src_a_e),
+        .srca(srca_e),
         .srcb(srcb_e),
         .alu_result(alu_result_e),
         .zero(zero_e)

--- a/test/i-type.S
+++ b/test/i-type.S
@@ -1,0 +1,9 @@
+.section .text
+.global _start
+_start:
+    addi t0, x0, -3
+    slti t1, t0, -1
+    ori  t2, t1, -4
+    andi s1, t2, 6
+.end:
+    beq x0, x0, .end

--- a/test/r-type.S
+++ b/test/r-type.S
@@ -1,0 +1,16 @@
+.section .text
+.global _start
+_start:
+    addi t0, x0, 2 # t0 = 2
+    add t1, t0, t0 # t1 = 2+2 =4
+    or  t2, t1, t0 # t2 = 3'b100 | 3'b010 = 3'b110 = 6
+    addi s1, t2, -1 # s1 = 6-1=5
+    and t3, t0, t2 # t3 = 3'b010 & 3'b110 =3'b010 = 2
+    sub t4, t1, s1 # t4 = 4-5=-1
+    slt t5, t0, t1 # t5 = 2<4=1
+    addi s1, x0, -3 
+    slt t6, s1, t4 # t6 = -3<-1=1
+    slt t6, t0, s1 # t6 = 2<-3=0
+
+.end:
+    beq x0, x0, .end


### PR DESCRIPTION
修正した項目
1. ALUのsrcAがrd1_eになっていたのでsrca_eに修正
2. sltによる32bit整数の大小比較を行う際、alu.svで明示的にsignedにしないと正常に比較できないっぽいので修正した。(正の数同士、負の数同士の大小比較はそのままのコードでも正常に実行されたけど、正の数と負の数の比較はsignedにしないとできなかった)
3. すでに実装済みの命令(R-type,I-type)の動作テスト用コードを作成