### PR TITLE
⚡ ALUControlを4bitに拡張

### DIFF
--- a/pipeline/alu.sv
+++ b/pipeline/alu.sv
@@ -1,7 +1,7 @@
 `default_nettype none
 
 module ALU (
-    input  wire  [2:0]   alu_control,
+    input  wire  [3:0]   alu_control,
     input  wire [31:0]   srca,
     input  wire [31:0]   srcb,
 
@@ -11,11 +11,11 @@ module ALU (
 
 always_comb begin
     case (alu_control)
-        3'b000 : alu_result = srca + srcb;
-        3'b001 : alu_result = srca - srcb;
-        3'b010 : alu_result = srca & srcb;
-        3'b011 : alu_result = srca | srcb;
-        3'b101 : alu_result = $signed(srca) < $signed(srcb);
+        4'b0000 : alu_result = srca + srcb;
+        4'b0001 : alu_result = srca - srcb;
+        4'b0010 : alu_result = srca & srcb;
+        4'b0011 : alu_result = srca | srcb;
+        4'b0101 : alu_result = $signed(srca) < $signed(srcb);
         default: begin
             alu_result = 32'hDEADBEEF;
             $display("Unknown ALU command.");

--- a/pipeline/cpu.sv
+++ b/pipeline/cpu.sv
@@ -13,7 +13,7 @@ module CPU(
     logic           mem_write_d;
     logic           jump_d;
     logic           branch_d;
-    logic   [2:0]   alu_control_d;
+    logic   [3:0]   alu_control_d;
     logic           alu_src_d;
     logic   [1:0]   imm_src_d;
 
@@ -32,7 +32,7 @@ module CPU(
     // IF/ID register
     logic   [31: 0] instr_d;
     logic   [31: 0] pc_d;
-    logic   [31: 0] pc_plus_4_d; 
+    logic   [31: 0] pc_plus_4_d;
 
     // Decode stage
     logic   [31: 0] rd1_d, rd2_d;
@@ -53,7 +53,7 @@ module CPU(
     logic           mem_write_e;
     logic           jump_e;
     logic           branch_e;
-    logic   [2:0]   alu_control_e;
+    logic   [3:0]   alu_control_e;
     logic           alu_src_e;
     logic           pc_alu_src_e;
     logic   [31:0]  pc_alu_src_a;

--- a/pipeline/decoder.sv
+++ b/pipeline/decoder.sv
@@ -7,7 +7,7 @@ module Decoder(
 
     output  logic [1:0] result_src,
     output  logic       mem_write,
-    output  logic [2:0] alu_control,
+    output  logic [3:0] alu_control,
     output  logic       alu_src,
     output  logic [1:0] imm_src,
     output  logic       reg_write,
@@ -66,7 +66,6 @@ always_comb begin
             branch     = 1'b1;
             jump       = 1'b0;
             pc_alu_src = 1'b0;
-
         end
         // addi
         7'b0010011 : begin
@@ -114,7 +113,6 @@ always_comb begin
             jump       = 1'b0;
         end
     endcase
-    
 end
 
 logic [1:0] op5_funct7_5;
@@ -122,24 +120,24 @@ assign op5_funct7_5 = {op[5],funct7[5]};
 
 always_comb begin
     case(alu_op)
-        2'b00 : alu_control = 3'b000;
-        2'b01 : alu_control = 3'b001;
+        2'b00 : alu_control = 4'b0000;
+        2'b01 : alu_control = 4'b0001;
         2'b10 : begin
             case(funct3)
                 3'b000 : begin
                     
                     case (op5_funct7_5)
-                        2'b11 : alu_control = 3'b001;
-                        default : alu_control = 3'b000;
+                        2'b11 : alu_control = 4'b0001;
+                        default : alu_control = 4'b0000;
                     endcase
                 end
-                3'b010 : alu_control = 3'b101;
-                3'b110 : alu_control = 3'b011;
-                3'b111 : alu_control = 3'b010;
-                default : alu_control = 3'b000;
+                3'b010 : alu_control = 4'b0101;
+                3'b110 : alu_control = 4'b0011;
+                3'b111 : alu_control = 4'b0010;
+                default : alu_control = 4'b0000;
             endcase
         end
-        default : alu_control = 3'b000;
+        default : alu_control = 4'b0000;
     endcase
 end
 


### PR DESCRIPTION
# Summary
命令の種類を増やすために、`ALUControl`を4bitに拡張しました。

## 変更点
### 共通
- `alu_control_*`の定義を[3:0]に変更しました。
- 既存の命令は、先頭に0を追加して4bitに拡張しました。

## 動作確認
`jalr.S`にて動作確認済みです。
![image](https://github.com/wakuto/our_first_cpu/assets/58902691/47572912-316f-4bd2-b06b-5762b52c6bd0)