### PR TITLE
⚡ XOR命令の実装

### DIFF
--- a/pipeline/alu.sv
+++ b/pipeline/alu.sv
@@ -16,6 +16,7 @@ always_comb begin
         4'b0010 : alu_result = srca & srcb;
         4'b0011 : alu_result = srca | srcb;
         4'b0101 : alu_result = $signed(srca) < $signed(srcb);
+        4'b0100 : alu_result = srca ^ srcb;
         default: begin
             alu_result = 32'hDEADBEEF;
             $display("Unknown ALU command.");

--- a/pipeline/decoder.sv
+++ b/pipeline/decoder.sv
@@ -125,13 +125,13 @@ always_comb begin
         2'b10 : begin
             case(funct3)
                 3'b000 : begin
-                    
                     case (op5_funct7_5)
                         2'b11 : alu_control = 4'b0001;
                         default : alu_control = 4'b0000;
                     endcase
                 end
                 3'b010 : alu_control = 4'b0101;
+                3'b100 : alu_control = 4'b0100;
                 3'b110 : alu_control = 4'b0011;
                 3'b111 : alu_control = 4'b0010;
                 default : alu_control = 4'b0000;

--- a/test/r-type.S
+++ b/test/r-type.S
@@ -30,6 +30,12 @@ _start:
     # t6 : 2<-3 = 0
     slt t6, t0, s1
 
+    # xor
+    addi s2, x0 ,1
+    # xor : 1 ^ 0 = 1
+    xor s3, x0, s2
+    # xor : 0 ^ 0 = 0
+    xor s3, x0, x0
 
 .end:
     beq x0, x0, .end

--- a/test/r-type.S
+++ b/test/r-type.S
@@ -1,16 +1,35 @@
 .section .text
 .global _start
 _start:
-    addi t0, x0, 2 # t0 = 2
-    add t1, t0, t0 # t1 = 2+2 =4
-    or  t2, t1, t0 # t2 = 3'b100 | 3'b010 = 3'b110 = 6
-    addi s1, t2, -1 # s1 = 6-1=5
-    and t3, t0, t2 # t3 = 3'b010 & 3'b110 =3'b010 = 2
-    sub t4, t1, s1 # t4 = 4-5=-1
-    slt t5, t0, t1 # t5 = 2<4=1
-    addi s1, x0, -3 
-    slt t6, s1, t4 # t6 = -3<-1=1
-    slt t6, t0, s1 # t6 = 2<-3=0
+    # add
+    # t0 = 2
+    addi t0, x0, 2
+    # t1 = 2+2 =4
+    add t1, t0, t0
+
+    # or
+    # t2 = 3'b100 | 3'b010 = 3'b110 = 6
+    or  t2, t1, t0
+
+    # and
+    # s1 = 6-1=5
+    addi s1, t2, -1
+    # t3 = 3'b010 & 3'b110 =3'b010 = 2
+    and t3, t0, t2
+
+    # sub
+    # t4 = 4-5=-1
+    sub t4, t1, s1
+
+    # slt
+    # t5 : 2<4 = 1
+    slt t5, t0, t1
+    addi s1, x0, -3
+    # t6 : -3<-1 = 1
+    slt t6, s1, t4
+    # t6 : 2<-3 = 0
+    slt t6, t0, s1
+
 
 .end:
     beq x0, x0, .end


### PR DESCRIPTION
# Summary
XOR命令を実装しました。

## 変更内容
### alu.sv
- `alu_control = 4'b0100`としてXOR命令を実装しました。

### decoder.sv
- `alu_op`が2'b10、`funct3`が3'b100の際にXOR命令を実行するように`alu_control`を調整しました。

### r-type.S
- 今後命令を追加することを鑑みて、一目で何をテストするコードかわかるようにリファクタしました。
- XOR命令をテストするアセンブリを追加しました。

## 動作確認
`r-type.S`で動作確認済みです(命令はアセンブリを参照)。
![image](https://github.com/wakuto/our_first_cpu/assets/58902691/e9b1ba20-99ef-401b-99aa-c06748f93063)
