### PR TITLE
branch命令全般を追加

### DIFF
--- a/pipeline/alu.sv
+++ b/pipeline/alu.sv
@@ -15,8 +15,17 @@ always_comb begin
         4'b0001 : alu_result = srca - srcb;
         4'b0010 : alu_result = srca & srcb;
         4'b0011 : alu_result = srca | srcb;
-        4'b0101 : alu_result = $signed(srca) < $signed(srcb);
         4'b0100 : alu_result = srca ^ srcb;
+        4'b0101 : alu_result = $signed(srca) < $signed(srcb);
+        4'b0110 : alu_result = $unsigned(srca) < $unsigned(srcb);
+        4'b0111 : alu_result = srca << srcb;
+        4'b1000 : alu_result = srca >> srcb;
+        4'b1001 : alu_result = srca >>> srcb;
+        4'b1010 : alu_result = srca == srcb;
+        4'b1011 : alu_result = srca != srcb;
+        4'b1100 : alu_result = $signed(srca) >= $signed(srcb);
+        4'b1101 : alu_result = $unsigned(srca) >= $unsigned(srcb);
+
         default: begin
             alu_result = 32'hDEADBEEF;
             $display("Unknown ALU command.");

--- a/pipeline/cpu.sv
+++ b/pipeline/cpu.sv
@@ -69,6 +69,7 @@ module CPU(
     
     logic          pc_src_e;
     logic          zero_e;
+    logic          branch_result_e;
     
     // EX/MEM register
     logic   [31:0] alu_result_m;
@@ -108,7 +109,8 @@ module CPU(
     );
 
     assign pc_plus_4_f = pc_f + 4;
-    assign pc_src_e = jump_e | (branch_e & zero_e);
+    assign pc_src_e = jump_e | branch_result_e;
+
     always_comb begin
         case(pc_src_e)
             2'b00:   pc_next   = pc_plus_4_f;
@@ -116,6 +118,15 @@ module CPU(
             // 2'b10:   pc_next   = alu_result;
             default: pc_next = 32'hdeadbeef;
         endcase
+    end
+
+    always_comb begin
+        if (branch_e) begin
+            branch_result_e = alu_result_e[0];
+        end
+        else begin
+            branch_result_e = 1'b0;
+        end
     end
 
     always_ff @(posedge clk) begin

--- a/pipeline/decoder.sv
+++ b/pipeline/decoder.sv
@@ -119,26 +119,45 @@ logic [1:0] op5_funct7_5;
 assign op5_funct7_5 = {op[5],funct7[5]};
 
 always_comb begin
-    case(alu_op)
-        2'b00 : alu_control = 4'b0000;
-        2'b01 : alu_control = 4'b0001;
-        2'b10 : begin
-            case(funct3)
-                3'b000 : begin
-                    case (op5_funct7_5)
-                        2'b11 : alu_control = 4'b0001;
-                        default : alu_control = 4'b0000;
-                    endcase
-                end
-                3'b010 : alu_control = 4'b0101;
-                3'b100 : alu_control = 4'b0100;
-                3'b110 : alu_control = 4'b0011;
-                3'b111 : alu_control = 4'b0010;
-                default : alu_control = 4'b0000;
-            endcase
-        end
-        default : alu_control = 4'b0000;
-    endcase
+    if(branch) begin
+        case(funct3)
+            //beq
+            3'b000 : alu_control = 4'b1010;
+            //bne
+            3'b001 : alu_control = 4'b1011;
+            //blt
+            3'b100 : alu_control = 4'b0101;
+            //bge
+            3'b101 : alu_control = 4'b1100;
+            //bltu
+            3'b110 : alu_control = 4'b0110;
+            //bgeu
+            3'b111 : alu_control = 4'b1101;
+            default: alu_control = 4'b0000;
+        endcase
+    end
+    else begin
+        case(alu_op)
+            2'b00 : alu_control = 4'b0000;
+            2'b01 : alu_control = 4'b0001;
+            2'b10 : begin
+                case(funct3)
+                    3'b000 : begin
+                        case (op5_funct7_5)
+                            2'b11 : alu_control = 4'b0001;
+                            default : alu_control = 4'b0000;
+                        endcase
+                    end
+                    3'b010 : alu_control = 4'b0101;
+                    3'b100 : alu_control = 4'b0100;
+                    3'b110 : alu_control = 4'b0011;
+                    3'b111 : alu_control = 4'b0010;
+                    default : alu_control = 4'b0000;
+                endcase
+            end
+            default : alu_control = 4'b0000;
+        endcase
+    end
 end
 
 endmodule

--- a/test/branch.S
+++ b/test/branch.S
@@ -17,7 +17,7 @@ BNE_TEST:
 BLT_TEST:
     addi t2, x0, -1
     # -1<1
-    blt t2, t1, BLTU_TEST
+    blt t2, t0, BLTU_TEST
     nop
     nop
     nop
@@ -28,7 +28,7 @@ BLT_TEST:
 
 BLTU_TEST:
     # 1<デカい数
-    bltu t1, t2, BGE_TEST
+    bltu t0, t2, BGE_TEST
     nop
     nop
     nop
@@ -48,8 +48,8 @@ BGE_TEST:
     nop
 
 BGEU_TEST:
-    # 1<デカい数
-    bgeu t2, t3, .end
+    # 1<=デカい数
+    bgeu t0, t3, .end
     nop
     nop
     nop

--- a/test/branch.S
+++ b/test/branch.S
@@ -1,0 +1,61 @@
+.section .text
+.global _start
+_start:
+    addi t0, x0, 1
+    beq t0, t0, BNE_TEST
+    nop
+    nop
+    nop
+
+BNE_TEST:
+    # 1!=0
+    bne t0, x0, BLT_TEST 
+    nop
+    nop
+    nop
+
+BLT_TEST:
+    addi t2, x0, -1
+    # -1<1
+    blt t2, t1, BLTU_TEST
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+
+
+BLTU_TEST:
+    # 1<デカい数
+    bltu t1, t2, BGE_TEST
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+
+BGE_TEST:
+    addi t3, x0, -1
+    # -1<=-1
+    bge t2, t3, BGEU_TEST
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+
+BGEU_TEST:
+    # 1<デカい数
+    bgeu t2, t3, .end
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+
+.end:
+    beq x0, x0, .end


### PR DESCRIPTION
# 概要

bne,blt,bge,bltu,bgeuを実装した.
branch命令全般をテストするアセンブリを追加した.
ALUデコーダの真理値表(Discordに貼ったリンク参照)を基に, ALUでできる演算を追加した.

## 変更点
branch命令はopcodeが共通だがfunct3が異なる. これに基づいて以下のような変更を行なった.

### alu.sv
- ALUでできる演算を追加(比較とシフト演算)
### cpu.sv
-  `pc_src_e = jump_e | (branch_e & zero_e)`を `pc_src_e = jump_e | branch_result_e`に変更.
- `branch`がたっているとき, `branch_result_e`に`alu_result_e`が入るように変更. (これにより, beqの分岐の際にzeroを使わなくなった)
### decoder.sv
- branchが立っている時, funct3によってalu_controlが決定されるようにした.

## 動作確認

<img width="1370" alt="スクリーンショット 2023-11-04 22 49 21" src="https://github.com/wakuto/our_first_cpu/assets/41273823/25376891-5137-4654-8482-9d6977221df9">
<img width="1371" alt="スクリーンショット 2023-11-04 22 49 34" src="https://github.com/wakuto/our_first_cpu/assets/41273823/7df75699-ed16-4582-b060-68cd43f032b6">

テスト用アセンブリを見ると分かる通り, branch命令の間にはnop命令が6個挿入されている.
branchが成功した時, 6個のnop(0x13)は飛ばされる.
波形を見ると,0x13は飛ばされていることがわかる.
