### PR TITLE
⚡️ shift系命令の追加

### DIFF
--- a/pipeline/alu.sv
+++ b/pipeline/alu.sv
@@ -18,9 +18,9 @@ always_comb begin
         4'b0100 : alu_result = srca ^ srcb;
         4'b0101 : alu_result = $signed(srca) < $signed(srcb);
         4'b0110 : alu_result = $unsigned(srca) < $unsigned(srcb);
-        4'b0111 : alu_result = srca << srcb;
-        4'b1000 : alu_result = srca >> srcb;
-        4'b1001 : alu_result = srca >>> srcb;
+        4'b0111 : alu_result = $signed(srca) << srcb[4:0];
+        4'b1000 : alu_result = $signed(srca) >> srcb[4:0];
+        4'b1001 : alu_result = $signed(srca) >>> srcb[4:0];
         4'b1010 : alu_result = srca == srcb;
         4'b1011 : alu_result = srca != srcb;
         4'b1100 : alu_result = $signed(srca) >= $signed(srcb);

--- a/pipeline/decoder.sv
+++ b/pipeline/decoder.sv
@@ -148,8 +148,15 @@ always_comb begin
                             default : alu_control = 4'b0000;
                         endcase
                     end
+                    3'b001 : alu_control = 4'b0111;
                     3'b010 : alu_control = 4'b0101;
                     3'b100 : alu_control = 4'b0100;
+                    3'b101 : begin
+                        case(op5_funct7_5)
+                            2'b11 : alu_control = 4'b1001;
+                            default : alu_control = 4'b1000;
+                        endcase
+                    end
                     3'b110 : alu_control = 4'b0011;
                     3'b111 : alu_control = 4'b0010;
                     default : alu_control = 4'b0000;

--- a/test/r-type.S
+++ b/test/r-type.S
@@ -37,5 +37,15 @@ _start:
     # xor : 0 ^ 0 = 0
     xor s3, x0, x0
 
+    # sll
+    # addi : s4 = -12 (FFFF FFF4)
+    addi s4, x0, -12
+    # srl : s5 = s4 >> 1 (7FFF FFFA)
+    srl s5, s4, s2
+    # sll : s5 = s4 << 1 (FFFF FFE8)
+    sll s5, s4, s2
+    # sra : s6 = s5 >>> 1 (FFFF FFF4)
+    sra s6, s5, s2
+
 .end:
     beq x0, x0, .end


### PR DESCRIPTION
# 概要

shift系列の命令(`sll`、`srl`、`sra`)を追加しました。

## 変更点

### alu.sv
- 論理シフト命令と算術シフト命令を追加しました。
- シフトするビット数を5bitに指定しました([PR#7](https://github.com/wakuto/our_first_cpu/pull/7)を参照)。
- `$signed`を付けないと挙動がおかしくなるため、shift元に`$signed`を付けました([本記事](https://hikalium.hatenablog.jp/entry/2017/07/10/091146)を参照)。

### decoder.sv
- 各shift演算を実行するためにdecoderを調整しました。

### r-type.S
- shift命令をテストするアセンブリを追加しました。

## 動作確認
r-type.Sで動作確認済みです。
![image](https://github.com/wakuto/our_first_cpu/assets/58902691/c1d7bcdf-9b5a-4825-8ffa-fed57379724c)

