### PR TITLE
Feature/load

### DIFF
--- a/pipeline/cpu.sv
+++ b/pipeline/cpu.sv
@@ -116,7 +116,6 @@ module CPU(
     logic           stall_d;
     logic           flush_d;
     logic           flush_e;
-    logic           forward_rd2_d;
     logic  [1:0]    forward_a_e;
     logic  [1:0]    forward_b_e;
 
@@ -294,7 +293,7 @@ module CPU(
             funct3_e <= 0;
         end else begin
             rd1_e <= rd1_d;
-            rd2_e <= forward_rd2_d ? result_w : rd2_d;
+            rd2_e <= rd2_d;
             pc_e <= pc_d;
             imm_ext_e <= imm_ext_d;
             pc_plus_4_e <= pc_plus_4_d;
@@ -400,6 +399,7 @@ module CPU(
             3'b000: write_mask = 4'b0001;
             3'b001: write_mask = 4'b0011;
             3'b010: write_mask = 4'b1111;
+            default:write_mask = 4'b1111;
         endcase
     end
 
@@ -458,7 +458,6 @@ module CPU(
         .stall_d(stall_d),
         .flush_d(flush_d),
         .flush_e(flush_e),
-        .forward_rd2_d(forward_rd2_d),
         .forward_a_e(forward_a_e),
         .forward_b_e(forward_b_e)
     );

--- a/pipeline/cpu.sv
+++ b/pipeline/cpu.sv
@@ -389,7 +389,8 @@ module CPU(
         .address(alu_result_m),
         .read_data(read_data_m),
         .write_enable(mem_write_m),
-        .write_data(write_data_m)
+        .write_data(write_data_m),
+        .funct3(funct3_m)
     );
     
     always_ff @(posedge clk) begin

--- a/pipeline/decoder.sv
+++ b/pipeline/decoder.sv
@@ -5,11 +5,11 @@ module Decoder(
     input   wire [2:0] funct3,
     input   wire [6:0] funct7,
 
-    output  logic [1:0] result_src,
+    output  logic [2:0] result_src,
     output  logic       mem_write,
     output  logic [3:0] alu_control,
     output  logic       alu_src,
-    output  logic [1:0] imm_src,
+    output  logic [2:0] imm_src,
     output  logic       reg_write,
     output  logic       jump,
     output  logic       branch,
@@ -25,7 +25,7 @@ always_comb begin
         // lw,lb,lh,lbu,lhu
         7'b0000011 : begin
             reg_write  = 1;
-            imm_src    = 2'b0;
+            imm_src    = 3'b0;
             alu_src    = 1;
             mem_write  = 0;
             result_src = 1;
@@ -36,7 +36,7 @@ always_comb begin
         // sw,sb,sh(S-形式)
         7'b0100011 : begin
             reg_write  = 0;
-            imm_src    = 2'b01;
+            imm_src    = 3'b01;
             alu_src    = 1;
             mem_write  = 1;
             result_src = 0;
@@ -58,7 +58,7 @@ always_comb begin
         // B-形式
         7'b1100011 : begin
             reg_write  = 0;
-            imm_src    = 2'b10;
+            imm_src    = 3'b10;
             alu_src    = 0;
             mem_write  = 0;
             result_src = 0;
@@ -70,7 +70,7 @@ always_comb begin
         // addi,slli,slti,sltiu,xori,srli,srai,ori,andi
         7'b0010011 : begin
             reg_write  = 1;
-            imm_src    = 2'b00;
+            imm_src    = 3'b00;
             alu_src    = 1;
             mem_write  = 0;
             result_src = 0;
@@ -81,10 +81,10 @@ always_comb begin
         // jal
         7'b1101111 : begin
             reg_write  = 1;
-            imm_src    = 2'b11;
+            imm_src    = 3'b11;
             alu_src    = 0;
             mem_write  = 0;
-            result_src = 2'b10;
+            result_src = 3'b10;
             alu_op     = 2'b00;
             branch     = 1'b0;
             jump       = 1'b1;
@@ -93,14 +93,38 @@ always_comb begin
         // jalr
         7'b1100111 : begin
             reg_write  = 1;
-            imm_src    = 2'b00;
+            imm_src    = 3'b00;
             alu_src    = 1;
             mem_write  = 0;
-            result_src = 2'b10;
+            result_src = 3'b10;
             alu_op     = 2'b10;
             branch     = 1'b0;
             jump       = 1'b1;
             pc_alu_src = 1'b1;
+        end
+        // lui(U-type)
+        7'b0110111 : begin
+            reg_write  = 1;
+            imm_src    = 3'b100;
+            alu_src    = 1;
+            mem_write  = 0;
+            result_src = 3'b11;
+            alu_op     = 2'b0;
+            branch     = 1'b0;
+            jump       = 1'b0;
+            pc_alu_src = 1'b0;
+        end
+        // auipc(U-type)
+        7'b0010111 : begin
+            reg_write  = 1;
+            imm_src    = 3'b100;
+            alu_src    = 1;
+            mem_write  = 0;
+            result_src = 3'b100;
+            alu_op     = 2'b0;
+            branch     = 1'b0;
+            jump       = 1'b0;
+            pc_alu_src = 1'b0;
         end
         default : begin
             reg_write  = 0;

--- a/pipeline/decoder.sv
+++ b/pipeline/decoder.sv
@@ -22,7 +22,7 @@ logic [1:0] alu_op;
 
 always_comb begin
     case (op)
-        // lw
+        // lw,lb,lh,lbu,lhu
         7'b0000011 : begin
             reg_write  = 1;
             imm_src    = 2'b0;
@@ -33,7 +33,7 @@ always_comb begin
             branch     = 1'b0;
             jump       = 1'b0;
         end
-        // sw
+        // sw,sb,sh(S-形式)
         7'b0100011 : begin
             reg_write  = 0;
             imm_src    = 2'b01;
@@ -55,7 +55,7 @@ always_comb begin
             branch     = 1'b0;
             jump       = 1'b0;
         end
-        // beq
+        // B-形式
         7'b1100011 : begin
             reg_write  = 0;
             imm_src    = 2'b10;
@@ -67,7 +67,7 @@ always_comb begin
             jump       = 1'b0;
             pc_alu_src = 1'b0;
         end
-        // addi
+        // addi,slli,slti,sltiu,xori,srli,srai,ori,andi
         7'b0010011 : begin
             reg_write  = 1;
             imm_src    = 2'b00;

--- a/pipeline/dmemory.sv
+++ b/pipeline/dmemory.sv
@@ -9,11 +9,14 @@ module DMemory (
     output logic [31: 0]    read_data
 );
 
-logic [31:0] dmemory [0:1023];
+logic [7:0] dmemory [0:1023];
 
 always_ff @(posedge clk) begin
     if(write_enable) begin
-        dmemory[address] <= {{8{write_mask[3]}}, {8{write_mask[2]}}, {8{write_mask[1]}},{8{write_mask[0]}}} & write_data;
+        if(write_mask[0]) dmemory[address] <= write_data[7:0];
+        if(write_mask[1]) dmemory[address+1] <= write_data[15:8];
+        if(write_mask[2]) dmemory[address+2] <= write_data[23:16];
+        if(write_mask[3]) dmemory[address+3] <= write_data[31:24];
     end
 end
 
@@ -27,7 +30,7 @@ always_comb begin
     if (address < 32'd32) begin
         read_data = 32'h1 << address;
     end else begin
-        read_data = dmemory[address];
+        read_data = {dmemory[address+3],dmemory[address+2],dmemory[address+1],dmemory[address]};
     end
 end
 

--- a/pipeline/dmemory.sv
+++ b/pipeline/dmemory.sv
@@ -5,7 +5,7 @@ module DMemory (
     input  wire [31: 0]     address,
     input  wire [31: 0]     write_data,
     input  wire             write_enable,
-    input  wire  [2:0]      funct3,
+    input  wire  [3:0]      write_mask,
     output logic [31: 0]    read_data
 );
 
@@ -13,12 +13,7 @@ logic [31:0] dmemory [0:1023];
 
 always_ff @(posedge clk) begin
     if(write_enable) begin
-        case(funct3)
-            3'b000: dmemory[address] <= write_data[7:0];
-            3'b001: dmemory[address] <= write_data[15:0];
-            3'b010: dmemory[address] <= write_data;
-            default:dmemory[address] <= write_data;
-        endcase
+        dmemory[address] <= {{8{write_mask[3]}}, {8{write_mask[2]}}, {8{write_mask[1]}},{8{write_mask[0]}}} & write_data;
     end
 end
 

--- a/pipeline/dmemory.sv
+++ b/pipeline/dmemory.sv
@@ -5,14 +5,20 @@ module DMemory (
     input  wire [31: 0]     address,
     input  wire [31: 0]     write_data,
     input  wire             write_enable,
-    output logic [31: 0]     read_data
+    input  wire  [2:0]      funct3,
+    output logic [31: 0]    read_data
 );
 
 logic [31:0] dmemory [0:1023];
 
 always_ff @(posedge clk) begin
     if(write_enable) begin
-        dmemory[address] <= write_data;
+        case(funct3)
+            3'b000: dmemory[address] <= write_data[7:0];
+            3'b001: dmemory[address] <= write_data[15:0];
+            3'b010: dmemory[address] <= write_data;
+            default:dmemory[address] <= write_data;
+        endcase
     end
 end
 

--- a/pipeline/hazard.sv
+++ b/pipeline/hazard.sv
@@ -7,7 +7,7 @@ module Hazard (
     input wire [4:0]  rs2_e,
     input wire [4:0]  rd_e,
     input wire        pc_src_e,
-    input wire [1:0]  result_src_e,
+    input wire [2:0]  result_src_e,
     input wire [4:0]  rd_m,
     input wire        reg_write_m,
     input wire [4:0]  rd_w,
@@ -17,14 +17,12 @@ module Hazard (
     output logic      stall_d,
     output logic      flush_d,
     output logic      flush_e,
-    output logic      forward_rd2_d,
     output logic [1:0]forward_a_e,
     output logic [1:0]forward_b_e
 );
 logic lwstall;
 
 always_comb begin
-    forward_rd2_d = rs2_d == rd_w;
     if(((rs1_e == rd_m) & reg_write_m) & (rs1_e != 0)) begin
         forward_a_e = 2'b10;
     end

--- a/test/load.S
+++ b/test/load.S
@@ -1,0 +1,19 @@
+.section .text
+.global _start
+_start:
+    addi t0,x0,100
+    addi t1,x0,-1000
+    sw t1, 0(t0)
+    addi t2,x0,-500
+    sw t2, 10(t0)
+
+    lb      s0, 0(t0)
+    lh      s1, 0(t0)
+    lw      s2, 0(t0)
+    lbu     s3, 0(t0)
+    lhu     s4, 0(t0)
+
+    lw      s5, 10(t0)
+
+.end:
+    beq x0, x0, .end

--- a/test/store.S
+++ b/test/store.S
@@ -1,0 +1,15 @@
+.section .text
+.global _start
+_start:
+    addi t0,x0,100
+    addi t1,x0,-1000
+    sb t1, 0(t0)
+    sh t1, 1(t0)
+    sw t1, 2(t0)
+
+    lw s0, 0(t0)
+    lw s1, 1(t0)
+    lw s2, 2(t0)
+
+.end:
+    beq x0, x0, .end

--- a/test/store.S
+++ b/test/store.S
@@ -2,14 +2,21 @@
 .global _start
 _start:
     addi t0,x0,100
-    addi t1,x0,-1000
+    addi t1,x0,-1001
+
     sb t1, 0(t0)
-    sh t1, 1(t0)
-    sw t1, 2(t0)
+    sb x0, 1(t0)
+    sb x0, 2(t0)
+    sb x0, 3(t0)
+
+    sh t1, 4(t0)
+    sh x0, 6(t0)
+
+    sw t1, 8(t0)
 
     lw s0, 0(t0)
-    lw s1, 1(t0)
-    lw s2, 2(t0)
+    lw s1, 4(t0)
+    lw s2, 8(t0)
 
 .end:
     beq x0, x0, .end

--- a/test/u-type.S
+++ b/test/u-type.S
@@ -1,0 +1,10 @@
+.section .text
+.global _start
+_start:
+    lui t0,3
+    nop
+    nop
+    nop
+    auipc t0,3
+.end:
+    beq x0, x0, .end


### PR DESCRIPTION
# 概要
lb,lh,kbu,lhu命令を実装し, 動作確認した.
さらに, sb,sh命令を実装し, 動作確認した.

## 変更点

### cpu.sv
レジスタファイルに書き戻す際に, 元のロード命令のfunct3を参照して何bit書き戻すかを判断する必要があるので, funct3とopをパイプラインレジスタを用いてWritebackステージまで流す設計に変更した.
また, dmemoryにfunct3を入力するようにした.
(統一するためにreg_fileに対してもfunct3を渡す設計にしても良いかも？)

### decoder.sv
opcodeと命令を対応づけるコメント文の記述を変更・追記した.

### dmemory.sv
funct3をcpu.svから受け取り, それに応じてwrite_dataから何bitメモリに書き込むかを決定

### load.S
ロード命令の動作をテストするアセンブリを追加.

### store.S
ストア命令の動作をテストするアセンブリを追加

## 動作確認

<img width="1397" alt="スクリーンショット 2023-11-07 11 56 36" src="https://github.com/wakuto/our_first_cpu/assets/41273823/3632c132-03f3-43fb-b051-cb0d7b70161b">
上の画像では, ロード命令をテストしている. 
x8~x20は, それぞれlb,lh,lw,lbu,lhuでx6に等しい値をメモリからロードした結果である.
この結果から, いずれも正常に動作することが確認できた.
x21は, x7に等しい値をメモリからロードした結果である.
<img width="1001" alt="スクリーンショット 2023-11-07 12 39 44" src="https://github.com/wakuto/our_first_cpu/assets/41273823/16355e0b-5055-4ed7-979c-87404090032d">
上の画像では, ストア命令をテストしている. 
x8,9,18は, それぞれsb,sh,swによってメモリに書き込んだ値をlwでロードした結果である.
こちらも, 正常に動作することが確認できた.

### 追記(11/11)
funct3を直接dmemoryに入力する設計は, OpenMPWが想定する設計に反するため, dmemory内のfunct3を削除し,新たにwrite_maskを導入した.
write_maskは, 32bitのwrite_dataを8bit単位でdmemoryに書き込むかどうかを設定する4bitのマスク信号である.

また, load命令かどうかを判別するために使用していたop5_op4を削除した. 何故なら, result_src_wが3'b001ならばその時点でロード命令であると判別できるからである.

これらの変更を行った結果, i-type.S, load.S, store.S, u-type.Sについて動作確認を行ったところ, いずれも以前と同様の波形が出力されていることが確認できた.

### 追記(11/12)
sb,shで上位ビットに0を書き込まないようにした.
store.Sのテストコードを変更.
forward_rd2_dという負の遺産が残っていたせいで, 書き込み処理に関して深刻な不具合をもたらしていたので, 削除.
write_maskのmuxにdefault句を追加.

r-type,i-type,u-type,store,loadで動作確認を行ったところ, いずれも以前と同じ波形が出力されていることが確認できた.