### PR TITLE
Feature/u type

### DIFF
--- a/pipeline/decoder.sv
+++ b/pipeline/decoder.sv
@@ -5,11 +5,11 @@ module Decoder(
     input   wire [2:0] funct3,
     input   wire [6:0] funct7,
 
-    output  logic [1:0] result_src,
+    output  logic [2:0] result_src,
     output  logic       mem_write,
     output  logic [3:0] alu_control,
     output  logic       alu_src,
-    output  logic [1:0] imm_src,
+    output  logic [2:0] imm_src,
     output  logic       reg_write,
     output  logic       jump,
     output  logic       branch,
@@ -25,7 +25,7 @@ always_comb begin
         // lw,lb,lh,lbu,lhu
         7'b0000011 : begin
             reg_write  = 1;
-            imm_src    = 2'b0;
+            imm_src    = 3'b0;
             alu_src    = 1;
             mem_write  = 0;
             result_src = 1;
@@ -36,7 +36,7 @@ always_comb begin
         // sw,sb,sh(S-形式)
         7'b0100011 : begin
             reg_write  = 0;
-            imm_src    = 2'b01;
+            imm_src    = 3'b01;
             alu_src    = 1;
             mem_write  = 1;
             result_src = 0;
@@ -58,7 +58,7 @@ always_comb begin
         // B-形式
         7'b1100011 : begin
             reg_write  = 0;
-            imm_src    = 2'b10;
+            imm_src    = 3'b10;
             alu_src    = 0;
             mem_write  = 0;
             result_src = 0;
@@ -70,7 +70,7 @@ always_comb begin
         // addi,slli,slti,sltiu,xori,srli,srai,ori,andi
         7'b0010011 : begin
             reg_write  = 1;
-            imm_src    = 2'b00;
+            imm_src    = 3'b00;
             alu_src    = 1;
             mem_write  = 0;
             result_src = 0;
@@ -81,10 +81,10 @@ always_comb begin
         // jal
         7'b1101111 : begin
             reg_write  = 1;
-            imm_src    = 2'b11;
+            imm_src    = 3'b11;
             alu_src    = 0;
             mem_write  = 0;
-            result_src = 2'b10;
+            result_src = 3'b10;
             alu_op     = 2'b00;
             branch     = 1'b0;
             jump       = 1'b1;
@@ -93,14 +93,38 @@ always_comb begin
         // jalr
         7'b1100111 : begin
             reg_write  = 1;
-            imm_src    = 2'b00;
+            imm_src    = 3'b00;
             alu_src    = 1;
             mem_write  = 0;
-            result_src = 2'b10;
+            result_src = 3'b10;
             alu_op     = 2'b10;
             branch     = 1'b0;
             jump       = 1'b1;
             pc_alu_src = 1'b1;
+        end
+        // lui(U-type)
+        7'b0110111 : begin
+            reg_write  = 1;
+            imm_src    = 3'b100;
+            alu_src    = 1;
+            mem_write  = 0;
+            result_src = 3'b11;
+            alu_op     = 2'b0;
+            branch     = 1'b0;
+            jump       = 1'b0;
+            pc_alu_src = 1'b0;
+        end
+        // auipc(U-type)
+        7'b0010111 : begin
+            reg_write  = 1;
+            imm_src    = 3'b100;
+            alu_src    = 1;
+            mem_write  = 0;
+            result_src = 3'b100;
+            alu_op     = 2'b0;
+            branch     = 1'b0;
+            jump       = 1'b0;
+            pc_alu_src = 1'b0;
         end
         default : begin
             reg_write  = 0;

--- a/test/u-type.S
+++ b/test/u-type.S
@@ -1,0 +1,10 @@
+.section .text
+.global _start
+_start:
+    lui t0,3
+    nop
+    nop
+    nop
+    auipc t0,3
+.end:
+    beq x0, x0, .end


### PR DESCRIPTION
# 概要

lui,auipcを実装した.

## 変更点

### cpu.sv
- imm_srcを3bitに拡張した. これにより, u-type命令の即値にも対応可能に
- result_src_wを3bitに拡張した.
- imm_extとpc_target_eをWriteBackステージまで伸ばした. これにより, 両者をレジスタファイルに書き戻せるようになった.

### decoder.sv
- luiとauipcを追加

## 動作確認
即値に0b11を設定して luiとauipcを実装すると,12bitぶん左シフトされて出力されていることがわかる.
さらに, auipcでは12bitシフトした即値に自らのPC(0x10)が足されていることがわかる.

<img width="1393" alt="スクリーンショット 2023-11-07 21 52 26" src="https://github.com/wakuto/our_first_cpu/assets/41273823/6775924e-e030-4d55-a6f1-8b9ef5acd761">