### PR TITLE
verilatorで指摘された部分を一部直した

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -17,6 +17,9 @@ run: cpu program.bin
 test: cpu test.bin
 	vvp cpu
 
+verilator:
+	verilator --binary -j $(MODULES)
+
 clean:
 	rm -rf cpu cpu.vcd
 

--- a/pipeline/alu.sv
+++ b/pipeline/alu.sv
@@ -16,15 +16,15 @@ always_comb begin
         4'b0010 : alu_result = srca & srcb;
         4'b0011 : alu_result = srca | srcb;
         4'b0100 : alu_result = srca ^ srcb;
-        4'b0101 : alu_result = $signed(srca) < $signed(srcb);
-        4'b0110 : alu_result = $unsigned(srca) < $unsigned(srcb);
+        4'b0101 : alu_result = {{31{1'b0}} , {$signed(srca) < $signed(srcb)}};
+        4'b0110 : alu_result = {{31{1'b0}} , {$unsigned(srca) < $unsigned(srcb)}};
         4'b0111 : alu_result = $signed(srca) << srcb[4:0];
         4'b1000 : alu_result = $signed(srca) >> srcb[4:0];
         4'b1001 : alu_result = $signed(srca) >>> srcb[4:0];
-        4'b1010 : alu_result = srca == srcb;
-        4'b1011 : alu_result = srca != srcb;
-        4'b1100 : alu_result = $signed(srca) >= $signed(srcb);
-        4'b1101 : alu_result = $unsigned(srca) >= $unsigned(srcb);
+        4'b1010 : alu_result = {{31{1'b0}} , {srca==srcb}};
+        4'b1011 : alu_result = {{31{1'b0}} , {srca != srcb}};
+        4'b1100 : alu_result = {{31{1'b0}} , {$signed(srca) >= $signed(srcb)}};
+        4'b1101 : alu_result = {{31{1'b0}} , {$unsigned(srca) >= $unsigned(srcb)}};
 
         default: begin
             alu_result = 32'hDEADBEEF;

--- a/pipeline/cpu.sv
+++ b/pipeline/cpu.sv
@@ -129,8 +129,8 @@ module CPU(
 
     always_comb begin
         case(pc_src_e)
-            2'b00:   pc_next   = pc_plus_4_f;
-            2'b01:   pc_next   = pc_target_e;
+            1'b0:   pc_next   = pc_plus_4_f;
+            1'b1:   pc_next   = pc_target_e;
             // 2'b10:   pc_next   = alu_result;
             default: pc_next = 32'hdeadbeef;
         endcase
@@ -199,11 +199,11 @@ module CPU(
         case(result_src_w)
             3'b001: begin
                 case(funct3_w)
-                    3'b000:  wd3_w = $signed(result_w[7:0]);
-                    3'b001:  wd3_w = $signed(result_w[15:0]);
+                    3'b000:  wd3_w = 32'($signed(result_w[7:0]));
+                    3'b001:  wd3_w = 32'($signed(result_w[15:0]));
                     3'b010:  wd3_w = result_w;
-                    3'b100:  wd3_w = $unsigned(result_w[7:0]);
-                    3'b101:  wd3_w = $unsigned(result_w[15:0]);
+                    3'b100:  wd3_w = 32'($unsigned(result_w[7:0]));
+                    3'b101:  wd3_w = 32'($unsigned(result_w[15:0]));
                     default: wd3_w = result_w;
                 endcase
             end

--- a/pipeline/cpu_test.sv
+++ b/pipeline/cpu_test.sv
@@ -1,5 +1,4 @@
 `default_nettype none
-`timescale 1ns/1ps
 
 module cpu_test();
     logic clk;

--- a/pipeline/decoder.sv
+++ b/pipeline/decoder.sv
@@ -32,6 +32,7 @@ always_comb begin
             alu_op     = 2'b0;
             branch     = 1'b0;
             jump       = 1'b0;
+            pc_alu_src = 1'b0;
         end
         // sw,sb,sh(S-形式)
         7'b0100011 : begin
@@ -43,6 +44,7 @@ always_comb begin
             alu_op     = 2'b00;
             branch     = 1'b0;
             jump       = 1'b0;
+            pc_alu_src = 1'b0;
         end
         // R-形式
         7'b0110011 : begin
@@ -54,6 +56,7 @@ always_comb begin
             alu_op     = 2'b10;
             branch     = 1'b0;
             jump       = 1'b0;
+            pc_alu_src = 1'b0;
         end
         // B-形式
         7'b1100011 : begin
@@ -77,6 +80,7 @@ always_comb begin
             alu_op     = 2'b10;
             branch     = 1'b0;
             jump       = 1'b0;
+            pc_alu_src = 1'b0;
         end
         // jal
         7'b1101111 : begin
@@ -135,6 +139,7 @@ always_comb begin
             alu_op     = 0;
             branch     = 1'b0;
             jump       = 1'b0;
+            pc_alu_src = 1'b0;
         end
     endcase
 end


### PR DESCRIPTION
# 概要

verilatorで指摘された部分を一部だけ直した.

## 変更点

### pipeline/Makefile
- 変更内容
Makefileにverilatorコマンドを追加.
`make verilator`でverilatorによるシミュレーションが可能.

### alu.sv
32bitのalu_resultに1bitを返していた部分を32bitで返すように修正.

### cpu.sv
32bitのwd3_wに8~16bitを返していた部分を32bitで返すように修正.

# まだ修正できていないエラー

このエラーの治し方がわからないので教えてくれ

```
pipeline % make verilator
verilator --binary -j alu.sv cpu.sv decoder.sv dmemory.sv imemory.sv regfile.sv cpu_test.sv hazard.sv
%Warning-TIMESCALEMOD: alu.sv:3:8: Timescale missing on this module as other modules have it (IEEE 1800-2017 3.14.2.3)
    3 | module ALU (
      |        ^~~
                       cpu_test.sv:4:8: ... Location of module with timescale
    4 | module cpu_test();
      |        ^~~~~~~~
                       ... For warning description see https://verilator.org/warn/TIMESCALEMOD?v=5.018
                       ... Use "/* verilator lint_off TIMESCALEMOD */" and lint_on around source to disable this message.
%Warning-TIMESCALEMOD: cpu.sv:3:8: Timescale missing on this module as other modules have it (IEEE 1800-2017 3.14.2.3)
    3 | module CPU(
      |        ^~~
                       cpu_test.sv:4:8: ... Location of module with timescale
    4 | module cpu_test();
      |        ^~~~~~~~
%Warning-TIMESCALEMOD: decoder.sv:3:8: Timescale missing on this module as other modules have it (IEEE 1800-2017 3.14.2.3)
    3 | module Decoder(
      |        ^~~~~~~
                       cpu_test.sv:4:8: ... Location of module with timescale
    4 | module cpu_test();
      |        ^~~~~~~~
%Warning-TIMESCALEMOD: dmemory.sv:3:8: Timescale missing on this module as other modules have it (IEEE 1800-2017 3.14.2.3)
    3 | module DMemory (
      |        ^~~~~~~
                       cpu_test.sv:4:8: ... Location of module with timescale
    4 | module cpu_test();
      |        ^~~~~~~~
%Warning-TIMESCALEMOD: imemory.sv:3:8: Timescale missing on this module as other modules have it (IEEE 1800-2017 3.14.2.3)
    3 | module IMemory(
      |        ^~~~~~~
                       cpu_test.sv:4:8: ... Location of module with timescale
    4 | module cpu_test();
      |        ^~~~~~~~
%Warning-TIMESCALEMOD: regfile.sv:3:8: Timescale missing on this module as other modules have it (IEEE 1800-2017 3.14.2.3)
    3 | module Regfile(
      |        ^~~~~~~
                       cpu_test.sv:4:8: ... Location of module with timescale
    4 | module cpu_test();
      |        ^~~~~~~~
%Warning-LATCH: decoder.sv:23:1: Latch inferred for signal 'cpu_test.cpu.pc_alu_src_d' (not all control paths of combinational always assign a value)
                               : ... Suggest use of always_latch for intentional latches
   23 | always_comb begin
      | ^~~~~~~~~~~
%Error: Exiting due to 7 warning(s)
make: *** [verilator] Error 1
```
