### PR TITLE
topとcoreに分けた

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -1,4 +1,4 @@
-MODULES = alu.sv cpu.sv decoder.sv dmemory.sv imemory.sv regfile.sv cpu_test.sv hazard.sv
+MODULES = alu.sv top.sv core.sv decoder.sv dmemory.sv imemory.sv regfile.sv cpu_test.sv hazard.sv
 
 all: cpu
 
@@ -18,7 +18,7 @@ test: cpu test.bin
 	vvp cpu
 
 verilator:
-	verilator --binary -j $(MODULES)
+	verilator --lint-only -Wall --timing $(MODULES)
 
 clean:
 	rm -rf cpu cpu.vcd

--- a/pipeline/core.sv
+++ b/pipeline/core.sv
@@ -1,3 +1,5 @@
+`default_nettype none
+
 module Core(
     input   wire    clk,
     input   wire    rst,
@@ -9,7 +11,7 @@ module Core(
     input logic [31: 0]    read_data,
 
     output  wire [31:0]   pc,
-    input logic [31:0]  instr
+    input logic [31:0]  instruction
 );
     logic   [31: 0] pc_f;
     logic   [31: 0] instr_f;
@@ -274,7 +276,7 @@ module Core(
     assign write_enable = mem_write_m;
     assign write_data = write_data_m;
     assign pc = pc_f;
-    assign instr_f = instr;
+    assign instr_f = instruction;
 
     // write to ID/EX registers
     always_ff @(posedge clk) begin
@@ -458,3 +460,4 @@ module Core(
         .forward_b_e(forward_b_e)
     );
 endmodule
+`default_nettype wire

--- a/pipeline/cpu_test.sv
+++ b/pipeline/cpu_test.sv
@@ -4,13 +4,13 @@ module cpu_test();
     logic clk;
     logic rst;
     
-    CPU cpu(.clk(clk), .rst(rst));
+    Top top(.clk(clk), .rst(rst));
 
     initial begin
         $dumpfile("cpu.vcd");
-        $dumpvars(0, cpu);
+        $dumpvars(0, top);
         for (int i = 0; i < 32; i++) begin
-          $dumpvars(0, cpu.reg_file.regfile[i]);
+          $dumpvars(0, top.core.reg_file.regfile[i]);
         end
         clk = 0;
 

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -1,0 +1,42 @@
+`default_nettype none
+module Top(   
+    input  wire clk,
+    input  wire rst
+);
+    logic [31: 0] pc;
+    logic [31: 0] instr;
+
+    logic [31: 0] address;
+    logic [31: 0] write_data;
+    logic [ 3: 0] write_mask;
+    logic         write_enable;
+    logic [31: 0] read_data;
+
+    Core core(
+        .clk(clk),
+        .rst(rst),
+
+        .address(address),
+        .write_data(write_data),
+        .write_enable(write_enable),
+        .write_mask(write_mask),
+        .read_data(read_data),
+
+        .pc(pc),
+        .instr(instr)
+    );
+    
+    DMemory data_memory(
+        .clk(clk),
+        .address(address),
+        .read_data(read_data),
+        .write_enable(write_enable),
+        .write_data(write_data),
+        .write_mask(write_mask)
+    );
+    IMemory instruction_memory(
+        .pc(pc),
+        .instr(instr)
+    );
+endmodule
+`default_nettype wire

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -4,7 +4,7 @@ module Top(
     input  wire rst
 );
     logic [31: 0] pc;
-    logic [31: 0] instr;
+    logic [31: 0] instruction;
 
     logic [31: 0] address;
     logic [31: 0] write_data;
@@ -23,7 +23,7 @@ module Top(
         .read_data(read_data),
 
         .pc(pc),
-        .instr(instr)
+        .instruction(instruction)
     );
     
     DMemory data_memory(
@@ -36,7 +36,7 @@ module Top(
     );
     IMemory instruction_memory(
         .pc(pc),
-        .instr(instr)
+        .instr(instruction)
     );
 endmodule
 `default_nettype wire


### PR DESCRIPTION
# 概要



## 変更点

### pipeline/Makefile
- 変更内容
MODULESからcpu.svを削除. core.svとtop.svを追加.

### core.sv
core(cpu)のi/oにdmemoryとimemoryのi/oを反転して追加
core.sv内で配線されているdmemoryとimemoryを削除

### top.sv
core, dmemory, imemoryの入出力ポートをそれぞれ接続.

## 動作確認
i-type, branch,storeで動作確認.
レジスタ書き込み, メモリ書き込み, ジャンプ, 全て正常に動作しているので, おそらく問題なし.
