### PR TITLE
⚡ メモリのクロック同期

### DIFF
--- a/pipeline/core.sv
+++ b/pipeline/core.sv
@@ -8,11 +8,11 @@ module Core(
     output  wire  [31: 0]   write_data,
     output  wire            write_enable,
     output  logic [3:0]     write_mask,
-    input   logic [31: 0]   read_data,
+    input   wire  [31: 0]   read_data,
 
     output  wire  [31:0]    pc,
-    input   logic [31:0]    instruction,
-    input   logic           valid
+    input   wire  [31:0]    instruction,
+    input   wire            valid
 );
     logic   [31: 0] pc_f;
     logic   [31: 0] instr_f;

--- a/pipeline/core.sv
+++ b/pipeline/core.sv
@@ -1,17 +1,18 @@
 `default_nettype none
 
 module Core(
-    input   wire    clk,
-    input   wire    rst,
+    input   wire            clk,
+    input   wire            rst,
 
-    output  wire [31: 0]     address,
-    output  wire [31: 0]     write_data,
-    output  wire             write_enable,
-    output  logic  [3:0]      write_mask,
-    input logic [31: 0]    read_data,
+    output  wire  [31: 0]   address,
+    output  wire  [31: 0]   write_data,
+    output  wire            write_enable,
+    output  logic [3:0]     write_mask,
+    input   logic [31: 0]   read_data,
 
-    output  wire [31:0]   pc,
-    input logic [31:0]  instruction
+    output  wire  [31:0]    pc,
+    input   logic [31:0]    instruction,
+    input   logic           valid
 );
     logic   [31: 0] pc_f;
     logic   [31: 0] instr_f;
@@ -99,7 +100,6 @@ module Core(
     logic   [31:0] imm_ext_m;
     logic [31:0] pc_target_m;
 
-
     //Data Memory
     logic   [31: 0] read_data_m;
     logic   [31: 0] result_w;
@@ -154,7 +154,7 @@ module Core(
             pc_f <= 0;
         end
         else begin
-            if (!stall_f) pc_f <= pc_next;
+            if (!stall_f && valid) pc_f <= pc_next;
         end
     end
 
@@ -165,7 +165,7 @@ module Core(
             pc_plus_4_d <= 0;
         end
         else begin
-            if (!stall_d) begin
+            if (!stall_d && valid) begin
                 instr_d <= instr_f;
                 pc_d <= pc_f;
                 pc_plus_4_d <= pc_plus_4_f;

--- a/pipeline/imemory.sv
+++ b/pipeline/imemory.sv
@@ -19,6 +19,7 @@ initial begin
 end
 
 logic        is_first_clk;
+logic [31:0] pc_fetching;
 logic [31:0] pc_fetched;
 
 always_ff @(posedge clk) begin
@@ -29,12 +30,17 @@ always_ff @(posedge clk) begin
         is_first_clk <= 1'b0;
     end
 
-    pc_fetched <= pc;
+    pc_fetched <= pc_fetching;
     instr <= {mem[pc+3], mem[pc+2], mem[pc+1], mem[pc]};
 end
 
 always_comb begin
     valid = ~is_first_clk && (pc_fetched == pc);
+    if (!valid) begin
+        pc_fetching = pc;
+    end else begin
+        pc_fetching = pc + 4;
+    end
 end
 
 endmodule

--- a/pipeline/imemory.sv
+++ b/pipeline/imemory.sv
@@ -13,7 +13,6 @@ logic [7:0] mem [0:4095];
 
 initial begin
     int fd = $fopen("../test/test.bin", "rb");
-    int i = 0;
     int res = 1;
     res = $fread(mem, fd, 0, 4096);
     $fclose(fd);

--- a/pipeline/imemory.sv
+++ b/pipeline/imemory.sv
@@ -1,8 +1,12 @@
 `default_nettype none
 
 module IMemory(
+    input  wire          clk,
     input  wire [31:0]   pc,
-    output logic [31:0]  instr
+    input  wire          rst,
+
+    output logic [31:0]  instr,
+    output logic         valid
 );
 
 logic [7:0] mem [0:4095];
@@ -15,21 +19,23 @@ initial begin
     $fclose(fd);
 end
 
+logic        is_first_clk;
+logic [31:0] pc_fetched;
+
+always_ff @(posedge clk) begin
+    // 現在のサイクルはリセット直後かどうか？
+    if (rst) begin
+        is_first_clk <= 1'b1;
+    end else begin
+        is_first_clk <= 1'b0;
+    end
+
+    pc_fetched <= pc;
+    instr <= {mem[pc+3], mem[pc+2], mem[pc+1], mem[pc]};
+end
+
 always_comb begin
-    instr = {mem[pc+3], mem[pc+2], mem[pc+1], mem[pc]};
-    /*
-    case (pc)
-        32'h0000 : instr = 32'h00002303; // lw x6, 0(x0)
-        32'h0004 : instr = 32'h00102383; // lw x7, 1(x0)
-        32'h0008 : instr = 32'h00736433; // or x8, x6, x7
-        32'h000c : instr = 32'h02802023; // sw x8, 32(x0)
-        32'h0010 : instr = 32'hfe0008e3; // beq x0, x0, -16
-        default: begin
-            instr = 32'h0000;
-            $display("die");
-        end
-    endcase
-    */
+    valid = ~is_first_clk && (pc_fetched == pc);
 end
 
 endmodule

--- a/pipeline/imemory.sv
+++ b/pipeline/imemory.sv
@@ -31,7 +31,7 @@ always_ff @(posedge clk) begin
     end
 
     pc_fetched <= pc_fetching;
-    instr <= {mem[pc+3], mem[pc+2], mem[pc+1], mem[pc]};
+    instr <= {mem[pc_fetching+3], mem[pc_fetching+2], mem[pc_fetching+1], mem[pc_fetching]};
 end
 
 always_comb begin

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -1,19 +1,19 @@
 `default_nettype none
-module Top(   
+module Top(
     input  wire clk,
     input  wire rst
 );
     logic [31: 0] pc;
-    logic [31: 0] instruction;
+    wire  [31: 0] instruction;
 
     logic [31: 0] address;
     logic [31: 0] write_data;
     logic [ 3: 0] write_mask;
     logic         write_enable;
-    logic [31: 0] read_data;
+    wire  [31: 0] read_data;
 
     // Instruction Memory
-    logic         valid;
+    wire          valid;
 
     Core core(
         .clk(clk),
@@ -29,7 +29,7 @@ module Top(
         .instruction(instruction),
         .valid(valid)
     );
-    
+
     DMemory data_memory(
         .clk(clk),
         .address(address),

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -12,6 +12,9 @@ module Top(
     logic         write_enable;
     logic [31: 0] read_data;
 
+    // Instruction Memory
+    logic         valid;
+
     Core core(
         .clk(clk),
         .rst(rst),
@@ -23,7 +26,8 @@ module Top(
         .read_data(read_data),
 
         .pc(pc),
-        .instruction(instruction)
+        .instruction(instruction),
+        .valid(valid)
     );
     
     DMemory data_memory(
@@ -35,8 +39,12 @@ module Top(
         .write_mask(write_mask)
     );
     IMemory instruction_memory(
+        .clk(clk),
         .pc(pc),
-        .instr(instruction)
+        .rst(rst),
+
+        .instr(instruction),
+        .valid(valid)
     );
 endmodule
 `default_nettype wire


### PR DESCRIPTION
# 概要

メモリをクロック同期にしました。
太字で書かれた部分は23/11/27に追記した変更です。

## 変更点

### imemory.sv
- imemoryをクロック同期にし、アドレスを入れた次のclkに命令を読み出すようにしました。
- ~上記の変更によりpcとinstrが1clk分ずれるため、都度ストールすることでpcが一致するようにしました。~
- **pcを先読みさせることにより、必要以上にストールを挟まないように変更しました。**

## 動作確認

i-test.Sにて動作確認した結果です。
`valid`が命令を有効化するかを表し、`valid`がTrueかつ`pc`と`pc_fetched`が一致する場合はパイプラインを有効にするようになっています。
![image](https://github.com/wakuto/our_first_cpu/assets/58902691/552c9432-e16b-4812-9eda-aeb61a19dd62)

**再びi-type.Sにて動作確認した結果です。
`pc_fetching`を導入し、`pc`を先読みしておくようにしました。これを`pc_fetched`に渡し、`pc`と比較させることで、毎回ストールを起こさなくても処理が進むようになりました。
分岐が発生した場合は、`pc_fetching`の値を`pc`と同じにすることで、1clk分遅延するようにしました。**
![image](https://github.com/wakuto/our_first_cpu/assets/58902691/54198ea3-8f96-4964-aedd-ddffbe2e74b3)