### PR TITLE
⚡ DMemoryをクロック同期に変更

### DIFF
--- a/pipeline/core.sv
+++ b/pipeline/core.sv
@@ -81,18 +81,17 @@ module Core(
     logic   [31:0] srca_e;
     logic   [31:0] srcb_e;
     logic   [31: 0] write_data_e;
-    
+
     logic          pc_src_e;
     logic          zero_e;
     logic          branch_result_e;
-    
-    
+
     // EX/MEM register
     logic   [31:0] alu_result_m;
     logic   [31:0] write_data_m;
     logic   [31:0] pc_plus_4_m;
     logic   [4 :0] rd_m;
-    
+
     logic           reg_write_m;
     logic   [2:0]   result_src_m;
     logic           mem_write_m;
@@ -102,12 +101,10 @@ module Core(
     logic   [31:0] imm_ext_m;
     logic [31:0] pc_target_m;
 
-    logic          read_enable_m;
-
     //Data Memory
     logic   [31: 0] read_data_m;
     logic   [31: 0] result_w;
-    
+
     // MEM/WB register
     logic   [31:0] alu_result_w;
     logic   [31:0] read_data_w;
@@ -124,7 +121,6 @@ module Core(
     logic   [31:0] imm_ext_w;
     logic [31:0] pc_target_w;
 
-    
     // hazard signal
     logic           stall_f;
     logic           stall_d;
@@ -141,7 +137,6 @@ module Core(
         case(pc_src_e)
             1'b0:   pc_next   = pc_plus_4_f;
             1'b1:   pc_next   = pc_target_e;
-            // 2'b10:   pc_next   = alu_result;
             default: pc_next = 32'hdeadbeef;
         endcase
     end
@@ -266,7 +261,6 @@ module Core(
 
     assign imm_ext_d = extend(imm_src_d, instr_d);
 
-    // assign pc_target_e = pc_e + imm_ext_e;
     assign pc_target_e = pc_alu_src_a + imm_ext_e;
     always_comb begin
         case(pc_alu_src_e)
@@ -289,7 +283,7 @@ module Core(
     assign write_data = write_data_m;
     assign pc = pc_f;
     assign instr_f = instruction;
-    assign read_enable = result_src_m == 2'b1;
+    assign read_enable = result_src_m == 3'b1;
 
     // write to ID/EX registers
     always_ff @(posedge clk) begin
@@ -370,7 +364,6 @@ module Core(
         .zero(zero_e)
     );
 
-    // assign result = result_src ? read_data : alu_result;
     always_comb begin
         case(result_src_w)
             3'b000 : result_w = alu_result_w;
@@ -423,14 +416,7 @@ module Core(
             default:write_mask = 4'b1111;
         endcase
 
-        if (result_src_m == 3'b001) begin
-            read_enable_m = 1'b1;
-        end else begin
-            read_enable_m = 1'b0;
-        end
     end
-
-    assign read_enable = read_enable_m;
 
     always_ff @(posedge clk) begin
         if (rst) begin

--- a/pipeline/dmemory.sv
+++ b/pipeline/dmemory.sv
@@ -6,7 +6,10 @@ module DMemory (
     input  wire [31: 0]     write_data,
     input  wire             write_enable,
     input  wire  [3:0]      write_mask,
-    output logic [31: 0]    read_data
+    input  wire             read_enable,
+
+    output logic [31: 0]    read_data,
+    output logic            read_valid
 );
 
 logic [7:0] dmemory [0:4095];
@@ -18,16 +21,19 @@ always_ff @(posedge clk) begin
         if(write_mask[2]) dmemory[address+2] <= write_data[23:16];
         if(write_mask[3]) dmemory[address+3] <= write_data[31:24];
     end
-end
 
-// 00000001
-// 00000010
-// 00000100
-// ...
-// 10000000
-// dmemory
-always_comb begin
-    read_data = {dmemory[address+3],dmemory[address+2],dmemory[address+1],dmemory[address]};
+    // read_enableがTrueの時、次のクロックで読み出しを実行
+    if (read_enable && !write_enable && !read_valid) begin
+        read_valid <= 1'b1;
+    end else begin
+        read_valid <= 1'b0;
+    end
+
+    if (read_valid) begin
+        read_data <= {dmemory[address+3],dmemory[address+2],dmemory[address+1],dmemory[address]};
+    end else begin
+        read_data <= read_data;
+    end
 end
 
 endmodule

--- a/pipeline/dmemory.sv
+++ b/pipeline/dmemory.sv
@@ -31,8 +31,6 @@ always_ff @(posedge clk) begin
 
     if (read_valid) begin
         read_data <= {dmemory[address+3],dmemory[address+2],dmemory[address+1],dmemory[address]};
-    end else begin
-        read_data <= read_data;
     end
 end
 

--- a/pipeline/hazard.sv
+++ b/pipeline/hazard.sv
@@ -10,11 +10,14 @@ module Hazard (
     input wire [2:0]  result_src_e,
     input wire [4:0]  rd_m,
     input wire        reg_write_m,
+    input wire        read_enable,
+    input wire        read_valid,
     input wire [4:0]  rd_w,
     input wire        reg_write_w,
 
     output logic      stall_f,
     output logic      stall_d,
+    output logic      stall_read,
     output logic      flush_d,
     output logic      flush_e,
     output logic [1:0]forward_a_e,
@@ -42,6 +45,7 @@ always_comb begin
     lwstall = result_src_e[0] & ((rs1_d == rd_e) | (rs2_d == rd_e));
     stall_f = lwstall;
     stall_d = lwstall;
+    stall_read = read_enable & !read_valid;
     flush_d = pc_src_e;
     flush_e = lwstall | pc_src_e;
 end

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -12,6 +12,9 @@ module Top(
     logic [31: 0] write_data;
     logic [ 3: 0] write_mask;
     logic         write_enable;
+    wire  [31: 0] read_data;
+    wire          read_enable;
+    wire          read_valid;
 
     logic [31: 0] read_data;
     logic [31: 0] dmemory_read_data;
@@ -68,9 +71,11 @@ module Top(
         .address(address),
         .write_data(write_data),
         .write_enable(write_enable),
+        .read_enable(read_enable),
         .write_mask(write_mask),
 
         .read_data(read_data),
+        .read_valid(read_valid),
 
         .pc(pc),
         .instruction(instruction),
@@ -81,6 +86,10 @@ module Top(
     DMemory data_memory(
         .clk(clk),
         .address(address),
+        .read_enable(read_enable),
+        .read_data(read_data),
+        .read_valid(read_valid),
+        .write_enable(write_enable),
         .write_data(write_data),
         .write_enable(write_enable && address != uart_rw_address),
         .write_mask(write_mask),

--- a/pipeline/uart.sv
+++ b/pipeline/uart.sv
@@ -14,9 +14,9 @@ module Uart(
     output logic read_ready,
     output logic [7:0] rx_data,
     output logic outValid
-); 
+);
     // baud_clk生成
-    logic [31:0] baud_counter = 32'b0;
+    logic [15:0] baud_counter;
     logic baud_clk = 1'b0;
     logic isRead;
 
@@ -27,7 +27,7 @@ module Uart(
 
     always_ff @(posedge clk) begin
         if (rst) begin
-            baud_counter <= 32'b0;
+            baud_counter <= 16'b0;
             baud_clk <= 1'b0;
             tx_counter <= 0;
             tx_data <= '1;
@@ -41,7 +41,7 @@ module Uart(
             rx_data <= '1;
         end else begin
             if (baud_counter == baud_max-1) begin
-                baud_counter <= 32'b0;
+                baud_counter <= 16'b0;
                 baud_clk <= ~baud_clk;
                 //送信
                 // カウントダウン
@@ -67,7 +67,7 @@ module Uart(
                     //カウントダウン
                     rx_counter <= rx_counter - 1;
                     // 算術右シフトし、rx_dataの最上位ビットにrxを代入
-                    rx_data <= $signed({rx,rx_data}) >>> 1;
+                    rx_data <= 8'($signed({rx,rx_data}) >>> 1);
                     // ストップビットが立つ直前で、outValidを1にする
                     if(rx_counter == 1 && isRead) begin
                         outValid <= 1'b1;


### PR DESCRIPTION
(このブランチは`feature/memory-clk-sync`にマージを向けてあるので、
- これを`feature/memory-clk-sync`にマージ後、`feature/memory-clk-sync`を`main`にマージ
- `feature/memory-clk-sync`を`main`にマージ後、このブランチのマージ先を`main`に変更(多分Assigneesしかできないので、この場合は教えてください)

のどちらかでマージをお願いします。)

# 概要

DMemoryの読み出しをクロック同期に変更しました。

## 変更点

### core.sv
- `result_src_m`がロード命令の場合、`read_enable`をTrueにするようにしました。
- 後述するDMemoryの変更用に、ID/EX間とEX/MEM間のストール条件に`stall_read`を追加しました。

### dmemory.sv
- 読み出しのタイミングを`read_enable`が立った次のサイクルに変更しました。

### hazard.sv
- `read_enable`と`!read_valid`の時に`stall_read`を有効にするよう変更しました。

### top.sv
- `dmemory.sv`と`core.sv`の変更に伴い、`read_enable`と`read_valid`を追加しました。

## 動作確認
- load.Sで動作確認を行いました。見た感じは合ってそう？
![image](https://github.com/wakuto/our_first_cpu/assets/58902691/494c4bb9-630d-4c96-ae99-0b20559f3afa)

- verilator実行済みです。
![image](https://github.com/wakuto/our_first_cpu/assets/58902691/f7acb4aa-1cbc-4007-8d31-4c617a075921)

## その他
makeした時にこんな感じのsorryって出てたっけ？
![image](https://github.com/wakuto/our_first_cpu/assets/58902691/51cd16cf-6bb1-497c-8986-6857c95f777d)