### PR TITLE
Feature/sram

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -1,4 +1,4 @@
-MODULES = alu.sv top.sv core.sv decoder.sv dmemory.sv imemory.sv regfile.sv cpu_test.sv hazard.sv uart.sv
+MODULES = alu.sv top.sv core.sv decoder.sv dmemory.sv imemory.sv regfile.sv cpu_test.sv hazard.sv uart.sv gf180mcu_fd_ip_sram__sram512x8m8wm1.sv
 
 all: cpu
 

--- a/pipeline/cpu_test.sv
+++ b/pipeline/cpu_test.sv
@@ -4,23 +4,88 @@
 module cpu_test();
     reg clk;
     logic rst;
+    logic imem_rst;
     logic tx;
 
-    wire CEN [0:3];
-    wire GWEN [0:3];
-    wire [7:0] WEN [0:3];
-    wire [8:0] A [0:3];
-    wire [7:0] D [0:3];
-    wire [7:0] Q [0:3];
-    
-    Top top(.clk(clk), .rst(rst), .tx(tx), .rx(tx), .CEN(CEN), .GWEN(GWEN), .WEN(WEN), .A(A), .D(D), .Q(Q));
+    wire CEN_dmem [0:3];
+    wire GWEN_dmem [0:3];
+    wire [7:0] WEN_dmem [0:3];
+    wire [8:0] A_dmem [0:3];
+    wire [7:0] D_dmem [0:3];
+    wire [7:0] Q_dmem [0:3];
 
+    logic CEN_imem [0:3];
+    logic GWEN_imem [0:3];
+    logic [7:0] WEN_imem [0:3];
+    logic [8:0] A_imem [0:3];
+    logic [7:0] D_imem [0:3];
+    logic [7:0] Q_imem [0:3];
+
+    wire CEN_imem_read [0:3];
+    wire GWEN_imem_read [0:3];
+    wire [7:0] WEN_imem_read [0:3];
+    wire [8:0] A_imem_read [0:3];
+    wire [7:0] D_imem_read [0:3];
+
+    logic CEN_imem_write [0:3];
+    logic GWEN_imem_write [0:3];
+    logic [7:0] WEN_imem_write [0:3];
+    logic [8:0] A_imem_write [0:3];
+    logic [7:0] D_imem_write [0:3];
+    
+    Top top(
+        .clk(clk),
+        .rst(rst),
+        .tx(tx), 
+        .rx(tx), 
+        .CEN_dmem(CEN_dmem), 
+        .GWEN_dmem(GWEN_dmem), 
+        .WEN_dmem(WEN_dmem), 
+        .A_dmem(A_dmem), 
+        .D_dmem(D_dmem), 
+        .Q_dmem(Q_dmem),
+        .CEN_imem(CEN_imem_read), 
+        .GWEN_imem(GWEN_imem_read), 
+        .WEN_imem(WEN_imem_read), 
+        .A_imem(A_imem_read), 
+        .D_imem(D_imem_read), 
+        .Q_imem(Q_imem)
+        );
+
+    logic [7:0] mem [0:4095];
     initial begin
         $dumpfile("cpu.vcd");
         $dumpvars(0);
         for (int i = 0; i < 32; i++) begin
           $dumpvars(0, top.core.reg_file.regfile[i]);
         end
+        for (int i = 0; i < 4; i++) begin
+          $dumpvars(0, top.instruction_memory.CEN[i]);
+          $dumpvars(0, CEN_imem_read[i]);
+          $dumpvars(0, top.CEN_imem[i]);
+        end
+        // 命令読み込み
+        $readmemh("../test/test.hex", mem);
+        //　最初のサイクルではCENをhighにする
+        clk = 0;
+        rst = 1;
+        for(int i=0; i<4; i++) CEN_imem_write[i] = 1;
+        @(posedge clk)
+        @(posedge clk)
+        for(int pc=0; pc < 100; pc++) begin
+            @(posedge clk)
+            for(int i=0;i<4;i++) begin
+                CEN_imem_write[i] = 0;
+                GWEN_imem_write[i] = 0;
+                WEN_imem_write[i]  = 8'b0;
+                A_imem_write[i] = pc;
+                D_imem_write[i] = mem[pc*4+i];
+                $display("pc: %d, instr: %h", pc, mem[pc*4+i]);
+            end
+        end
+        rst = 0;
+
+        //リセット
         clk = 0;
         rst = 1;
         @(posedge clk)
@@ -34,41 +99,88 @@ module cpu_test();
         clk <= ~clk;
     end
     
-    gf180mcu_fd_ip_sram__sram512x8m8wm1 gf180mcu_0(
+    always_comb begin
+        for(int i=0;i<4;i++) begin
+            CEN_imem[i] = rst ? CEN_imem_write[i] : CEN_imem_read[i];
+            GWEN_imem[i] = rst ? GWEN_imem_write[i] : GWEN_imem_read[i];
+            WEN_imem[i]  = rst ? WEN_imem_write[i]  : WEN_imem_read[i];
+            A_imem[i]    = rst ? A_imem_write[i]    : A_imem_read[i];
+            D_imem[i]    = rst ? D_imem_write[i]    : D_imem_read[i];
+        end
+    end
+
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 dmem_0(
         .CLK(clk),
-        .CEN(CEN[0]),
-        .GWEN(GWEN[0]),
-        .WEN(WEN[0]),
-        .A(A[0]),
-        .D(D[0]),
-        .Q(Q[0])
+        .CEN(CEN_dmem[0]),
+        .GWEN(GWEN_dmem[0]),
+        .WEN(WEN_dmem[0]),
+        .A(A_dmem[0]),
+        .D(D_dmem[0]),
+        .Q(Q_dmem[0])
     );
-    gf180mcu_fd_ip_sram__sram512x8m8wm1 gf180mcu_1(
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 dmem_1(
         .CLK(clk),
-        .CEN(CEN[1]),
-        .GWEN(GWEN[1]),
-        .WEN(WEN[1]),
-        .A(A[1]),
-        .D(D[1]),
-        .Q(Q[1])
+        .CEN(CEN_dmem[1]),
+        .GWEN(GWEN_dmem[1]),
+        .WEN(WEN_dmem[1]),
+        .A(A_dmem[1]),
+        .D(D_dmem[1]),
+        .Q(Q_dmem[1])
     );
-    gf180mcu_fd_ip_sram__sram512x8m8wm1 gf180mcu_2(
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 dmem_2(
         .CLK(clk),
-        .CEN(CEN[2]),
-        .GWEN(GWEN[2]),
-        .WEN(WEN[2]),
-        .A(A[2]),
-        .D(D[2]),
-        .Q(Q[2])
+        .CEN(CEN_dmem[2]),
+        .GWEN(GWEN_dmem[2]),
+        .WEN(WEN_dmem[2]),
+        .A(A_dmem[2]),
+        .D(D_dmem[2]),
+        .Q(Q_dmem[2])
     );
-    gf180mcu_fd_ip_sram__sram512x8m8wm1 gf180mcu_3(
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 dmem_3(
         .CLK(clk),
-        .CEN(CEN[3]),
-        .GWEN(GWEN[3]),
-        .WEN(WEN[3]),
-        .A(A[3]),
-        .D(D[3]),
-        .Q(Q[3])
+        .CEN(CEN_dmem[3]),
+        .GWEN(GWEN_dmem[3]),
+        .WEN(WEN_dmem[3]),
+        .A(A_dmem[3]),
+        .D(D_dmem[3]),
+        .Q(Q_dmem[3])
+    );
+
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 imem_0(
+        .CLK(clk),
+        .CEN(CEN_imem[0]),
+        .GWEN(GWEN_imem[0]),
+        .WEN(WEN_imem[0]),
+        .A(A_imem[0]),
+        .D(D_imem[0]),
+        .Q(Q_imem[0])
+    );
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 imem_1(
+        .CLK(clk),
+        .CEN(CEN_imem[1]),
+        .GWEN(GWEN_imem[1]),
+        .WEN(WEN_imem[1]),
+        .A(A_imem[1]),
+        .D(D_imem[1]),
+        .Q(Q_imem[1])
+    );
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 imem_2(
+        .CLK(clk),
+        .CEN(CEN_imem[2]),
+        .GWEN(GWEN_imem[2]),
+        .WEN(WEN_imem[2]),
+        .A(A_imem[2]),
+        .D(D_imem[2]),
+        .Q(Q_imem[2])
+    );
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 imem_3(
+        .CLK(clk),
+        .CEN(CEN_imem[3]),
+        .GWEN(GWEN_imem[3]),
+        .WEN(WEN_imem[3]),
+        .A(A_imem[3]),
+        .D(D_imem[3]),
+        .Q(Q_imem[3])
     );
 endmodule
 `default_nettype wire

--- a/pipeline/cpu_test.sv
+++ b/pipeline/cpu_test.sv
@@ -1,31 +1,74 @@
 `default_nettype none
+`timescale 1ns / 1ps
 
 module cpu_test();
-    logic clk;
+    reg clk;
     logic rst;
     logic tx;
+
+    wire CEN [0:3];
+    wire GWEN [0:3];
+    wire [7:0] WEN [0:3];
+    wire [8:0] A [0:3];
+    wire [7:0] D [0:3];
+    wire [7:0] Q [0:3];
     
-    // 動作確認ではエコーバックを行う
-    Top top(.clk(clk), .rst(rst), .tx(tx), .rx(tx));
+    Top top(.clk(clk), .rst(rst), .tx(tx), .rx(tx), .CEN(CEN), .GWEN(GWEN), .WEN(WEN), .A(A), .D(D), .Q(Q));
 
     initial begin
         $dumpfile("cpu.vcd");
-        $dumpvars(0, top);
+        $dumpvars(0);
         for (int i = 0; i < 32; i++) begin
           $dumpvars(0, top.core.reg_file.regfile[i]);
         end
         clk = 0;
-
         rst = 1;
         @(posedge clk)
         @(posedge clk)
         rst = 0;
-        #100000
+        @(posedge clk)
+        #1000000
         $finish;
     end
-    always #(5) begin
+    always #(500) begin
         clk <= ~clk;
     end
-
+    
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 gf180mcu_0(
+        .CLK(clk),
+        .CEN(CEN[0]),
+        .GWEN(GWEN[0]),
+        .WEN(WEN[0]),
+        .A(A[0]),
+        .D(D[0]),
+        .Q(Q[0])
+    );
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 gf180mcu_1(
+        .CLK(clk),
+        .CEN(CEN[1]),
+        .GWEN(GWEN[1]),
+        .WEN(WEN[1]),
+        .A(A[1]),
+        .D(D[1]),
+        .Q(Q[1])
+    );
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 gf180mcu_2(
+        .CLK(clk),
+        .CEN(CEN[2]),
+        .GWEN(GWEN[2]),
+        .WEN(WEN[2]),
+        .A(A[2]),
+        .D(D[2]),
+        .Q(Q[2])
+    );
+    gf180mcu_fd_ip_sram__sram512x8m8wm1 gf180mcu_3(
+        .CLK(clk),
+        .CEN(CEN[3]),
+        .GWEN(GWEN[3]),
+        .WEN(WEN[3]),
+        .A(A[3]),
+        .D(D[3]),
+        .Q(Q[3])
+    );
 endmodule
 `default_nettype wire

--- a/pipeline/dmemory.sv
+++ b/pipeline/dmemory.sv
@@ -2,33 +2,39 @@
 
 module DMemory (
     input  wire             clk,
+    input  wire             rst,
     input  wire [31: 0]     address,
     input  wire [31: 0]     write_data,
     input  wire             write_enable,
     input  wire  [3:0]      write_mask,
-    output logic [31: 0]    read_data
+    input  wire             read_enable,
+    output logic [31: 0]    read_data,
+    output logic            read_valid,
+
+    output logic CEN [0:3],
+    output logic GWEN [0:3],
+    output logic [7:0] WEN [0:3],
+    output logic [8:0] A [0:3],
+    output logic [7:0] D [0:3],
+    input  wire  [7:0] Q [0:3]
 );
 
-logic [7:0] dmemory [0:4095];
-
+always_comb begin
+    for(int i=0;i<4;i++) begin
+        CEN[i]  = rst;
+        GWEN[i] = !write_enable;
+        WEN[2'(address+i)]  = {8{!write_mask[i]}};
+        A[i] = 9'((address + i) >> 2);
+        D[i] = write_data[8*i +: 8];
+    end
+    read_data = {Q[3], Q[2], Q[1], Q[0]};
+end
 always_ff @(posedge clk) begin
-    if(write_enable) begin
-        if(write_mask[0]) dmemory[address] <= write_data[7:0];
-        if(write_mask[1]) dmemory[address+1] <= write_data[15:8];
-        if(write_mask[2]) dmemory[address+2] <= write_data[23:16];
-        if(write_mask[3]) dmemory[address+3] <= write_data[31:24];
+    if (read_enable && !write_enable && !read_valid) begin
+        read_valid <= 1'b1;
+    end else begin
+        read_valid <= 1'b0;
     end
 end
-
-// 00000001
-// 00000010
-// 00000100
-// ...
-// 10000000
-// dmemory
-always_comb begin
-    read_data = {dmemory[address+3],dmemory[address+2],dmemory[address+1],dmemory[address]};
-end
-
 endmodule
 `default_nettype wire

--- a/pipeline/gf180mcu_fd_ip_sram__sram512x8m8wm1.sv
+++ b/pipeline/gf180mcu_fd_ip_sram__sram512x8m8wm1.sv
@@ -1,0 +1,466 @@
+/*
+ * $Id: $
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http:www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Project:             018 5VGREEN SRAM
+ * Author:              GlobalFoundries PDK Authors
+ * Data Created:        05-06-2014
+ * Revision:		0.0
+ *
+ * Description:         gf180mcu_fd_ip_sram__sram512x8m8wm1 Simulation Model
+ */
+ /// sta-blackbox
+
+`timescale 1 ns / 1 ps
+
+module gf180mcu_fd_ip_sram__sram512x8m8wm1 (
+	CLK,
+	CEN,
+	GWEN,
+	WEN,
+	A,
+	D,
+	Q,
+	VDD,
+	VSS
+);
+
+input           CLK;
+input           CEN;    //Chip Enable
+input           GWEN;   //Global Write Enable
+input   [7:0]  	WEN;    //Write Enable
+input   [8:0]   A;
+input   [7:0]  	D;
+output	[7:0]	  Q;
+inout		VDD;
+inout		VSS;
+
+reg	[7:0]	mem[511:0];
+reg	[7:0]	qo_reg;
+
+wire		cen_flag;
+wire		write_flag;
+wire		read_flag;
+
+reg             ntf_Tcyc;	//notifier for clock period/low/high pulse
+reg             ntf_Tckh;
+reg             ntf_Tckl;
+
+reg		ntf_tcs;	//notifier for setup time
+reg		ntf_tas;
+reg		ntf_tds;
+reg		ntf_tws;
+reg		ntf_twis;
+
+reg             ntf_tch;	//notifier for hold time
+reg             ntf_tah;
+reg             ntf_tdh;
+reg             ntf_twh;
+reg             ntf_twih;
+
+wire		no_st_viol;	//no setup violation
+wire		no_hd_viol;	//no hold violation
+wire		no_ck_viol;	//no clock related violation
+
+reg             clk_dly;        //for read/write
+reg             write_flag_dly; //for write invalidation
+reg             read_flag_dly;  //for read invalidation
+reg             cen_dly;
+reg             cen_fell;       //detect CEN 1 -> 0 transition
+reg             cen_not_rst;    //detect CEN is not reset initially
+
+wire    [7:0]  we;       	//inversion of WEN
+wire    [7:0]  cd2;
+wire    [7:0]  cd4;
+wire    [7:0]  cd5;
+reg    	[7:0]  cdx;
+
+reg	[8:0]	marked_a;
+
+integer         i;
+
+assign Q = qo_reg;
+
+//---- for debugging
+wire    [7:0]  mem_0;
+wire	[7:0]  mem_1;
+wire	[7:0]  mem_2;
+wire	[7:0]  mem_3;
+assign mem_0 = mem[0];
+assign mem_1 = mem[1];
+assign mem_2 = mem[2];
+assign mem_3 = mem[3];
+
+always @(CEN) cen_dly = #100 CEN;
+always @(CEN or cen_dly) begin
+  if (!CEN & cen_dly) cen_fell = 1'b1;
+end
+
+always @(posedge CLK) begin
+  if (!CEN & !cen_fell & !cen_not_rst) cen_not_rst = 1;
+end
+
+always @(posedge cen_not_rst) begin
+  $display("-------- WARNING: CEN is not reset, memory is not operational ---------");
+  $display("-------- @Time %0t: scope = %m", $realtime, " ---------");
+end
+
+always @(posedge cen_fell) begin
+  $display("-------- MESSAGE: CEN is just reset, memory is operational ---------");
+  $display("-------- @Time %0t: scope = %m", $realtime, " ---------");
+end
+
+assign cen_flag   =  cen_fell & !CEN;
+assign write_flag =  cen_fell & !CEN & !GWEN & !(&WEN);
+assign read_flag  =  cen_fell & !CEN &  GWEN;
+
+reg cen_flag_dly;
+always @(cen_flag) cen_flag_dly = #100 cen_flag;
+
+specify
+  specparam Tcyc = 55600 : 55600 : 55600;
+  specparam Tckh = 25000 : 25000 : 25000;
+  specparam Tckl = 25000 : 25000 : 25000;
+
+  specparam tcs  = 5000 : 5000 : 5000;
+  specparam tas  = 5000 : 5000 : 5000;
+  specparam tds  = 5000 : 5000 : 5000;
+  specparam tws  = 5000 : 5000 : 5000;
+  specparam twis = 5000 : 5000 : 5000;
+
+  specparam tch  = 10000 : 10000 : 10000;
+  specparam tah  = 10000 : 10000 : 10000;
+  specparam tdh  = 10000 : 10000 : 10000;
+  specparam twh  = 10000 : 10000 : 10000;
+  specparam twih = 10000 : 10000 : 10000;
+
+  specparam ta   = 45000 : 45000 : 45000;
+
+  specparam Tdly  = 100 : 100: 100;
+
+//---- CLK period/pulse timing
+  $period (negedge CLK, Tcyc, ntf_Tcyc);
+  $width  (posedge CLK, Tckh, 0, ntf_Tckh);
+  $width  (negedge CLK, Tckl, 0, ntf_Tckl);
+
+//---- CEN setup/hold timing
+  $setup (negedge CEN, posedge CLK &&& cen_flag, tcs, ntf_tcs);
+  $setup (posedge CEN, posedge CLK &&& cen_flag, tcs, ntf_tcs);
+
+  $hold  (posedge CLK &&& cen_flag_dly, posedge CEN, tch, ntf_tch);
+  $hold  (posedge CLK &&& cen_flag,     negedge CEN, tch, ntf_tch);
+
+//---- GWEN setup/hold timing
+  $setup (negedge GWEN,  posedge CLK &&& cen_flag, tws, ntf_tws);
+  $setup (posedge GWEN,  posedge CLK &&& cen_flag, tws, ntf_tws);
+
+  $hold  (posedge CLK &&& cen_flag, posedge GWEN, twh, ntf_twh);
+  $hold  (posedge CLK &&& cen_flag, negedge GWEN, twh, ntf_twh);
+
+//---- WEN[7:0] setup/hold timing
+  $setup (negedge WEN[0],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (negedge WEN[1],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (negedge WEN[2],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (negedge WEN[3],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (negedge WEN[4],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (negedge WEN[5],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (negedge WEN[6],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (negedge WEN[7],  posedge CLK &&& write_flag, twis, ntf_twis);
+
+  $setup (posedge WEN[0],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (posedge WEN[1],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (posedge WEN[2],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (posedge WEN[3],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (posedge WEN[4],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (posedge WEN[5],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (posedge WEN[6],  posedge CLK &&& write_flag, twis, ntf_twis);
+  $setup (posedge WEN[7],  posedge CLK &&& write_flag, twis, ntf_twis);
+
+  $hold  (posedge CLK &&& write_flag, posedge WEN[0],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, posedge WEN[1],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, posedge WEN[2],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, posedge WEN[3],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, posedge WEN[4],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, posedge WEN[5],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, posedge WEN[6],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, posedge WEN[7],  twih, ntf_twih);
+
+  $hold  (posedge CLK &&& write_flag, negedge WEN[0],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, negedge WEN[1],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, negedge WEN[2],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, negedge WEN[3],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, negedge WEN[4],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, negedge WEN[5],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, negedge WEN[6],  twih, ntf_twih);
+  $hold  (posedge CLK &&& write_flag, negedge WEN[7],  twih, ntf_twih);
+
+//---- A[8:0] setup/hold timing
+  $setup (posedge A[0],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (posedge A[1],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (posedge A[2],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (posedge A[3],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (posedge A[4],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (posedge A[5],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (posedge A[6],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (posedge A[7],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (posedge A[8],  posedge CLK &&& cen_flag, tas, ntf_tas);
+
+  $setup (negedge A[0],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (negedge A[1],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (negedge A[2],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (negedge A[3],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (negedge A[4],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (negedge A[5],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (negedge A[6],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (negedge A[7],  posedge CLK &&& cen_flag, tas, ntf_tas);
+  $setup (negedge A[8],  posedge CLK &&& cen_flag, tas, ntf_tas);
+
+  $hold  (posedge CLK &&& cen_flag, negedge A[0],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, negedge A[1],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, negedge A[2],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, negedge A[3],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, negedge A[4],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, negedge A[5],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, negedge A[6],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, negedge A[7],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, negedge A[8],  tah, ntf_tah);
+
+  $hold  (posedge CLK &&& cen_flag, posedge A[0],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, posedge A[1],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, posedge A[2],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, posedge A[3],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, posedge A[4],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, posedge A[5],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, posedge A[6],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, posedge A[7],  tah, ntf_tah);
+  $hold  (posedge CLK &&& cen_flag, posedge A[8],  tah, ntf_tah);
+
+//---- D[7:0] setup/hold timing
+  $setup (posedge D[0],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (posedge D[1],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (posedge D[2],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (posedge D[3],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (posedge D[4],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (posedge D[5],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (posedge D[6],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (posedge D[7],  posedge CLK &&& write_flag, tds, ntf_tds);
+
+  $setup (negedge D[0],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (negedge D[1],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (negedge D[2],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (negedge D[3],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (negedge D[4],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (negedge D[5],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (negedge D[6],  posedge CLK &&& write_flag, tds, ntf_tds);
+  $setup (negedge D[7],  posedge CLK &&& write_flag, tds, ntf_tds);
+
+  $hold  (posedge CLK &&& write_flag, negedge D[0],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, negedge D[1],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, negedge D[2],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, negedge D[3],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, negedge D[4],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, negedge D[5],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, negedge D[6],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, negedge D[7],  tdh, ntf_tdh);
+
+  $hold  (posedge CLK &&& write_flag, posedge D[0],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, posedge D[1],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, posedge D[2],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, posedge D[3],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, posedge D[4],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, posedge D[5],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, posedge D[6],  tdh, ntf_tdh);
+  $hold  (posedge CLK &&& write_flag, posedge D[7],  tdh, ntf_tdh);
+
+//---- Output delay
+// rise transition:     0->1, z->1, Ta
+// fall transition:     1->0, 1->z, Ta
+// turn-off transition: 0->z, 1->z, Tcqx
+//if (!CEN & GWEN) (posedge CLK => (Q : 8'bx)) = (Ta, Ta, Tcqx);
+if ((CEN == 1'b0) && (GWEN == 1'b1)) (posedge CLK => (Q[0]  : 1'bx)) = (ta, ta);
+if ((CEN == 1'b0) && (GWEN == 1'b1)) (posedge CLK => (Q[1]  : 1'bx)) = (ta, ta);
+if ((CEN == 1'b0) && (GWEN == 1'b1)) (posedge CLK => (Q[2]  : 1'bx)) = (ta, ta);
+if ((CEN == 1'b0) && (GWEN == 1'b1)) (posedge CLK => (Q[3]  : 1'bx)) = (ta, ta);
+if ((CEN == 1'b0) && (GWEN == 1'b1)) (posedge CLK => (Q[4]  : 1'bx)) = (ta, ta);
+if ((CEN == 1'b0) && (GWEN == 1'b1)) (posedge CLK => (Q[5]  : 1'bx)) = (ta, ta);
+if ((CEN == 1'b0) && (GWEN == 1'b1)) (posedge CLK => (Q[6]  : 1'bx)) = (ta, ta);
+if ((CEN == 1'b0) && (GWEN == 1'b1)) (posedge CLK => (Q[7]  : 1'bx)) = (ta, ta);
+endspecify
+
+assign no_st_viol = ~(|{ntf_tcs, ntf_tas, ntf_tds, ntf_tws, ntf_twis});
+assign no_hd_viol = ~(|{ntf_tch, ntf_tah, ntf_tdh, ntf_twh, ntf_twih});
+assign no_ck_viol = ~(|{ntf_Tcyc, ntf_Tckh, ntf_Tckl});
+
+always @(CLK) clk_dly        = #Tdly CLK;
+always @(CLK) write_flag_dly = #200 write_flag;
+always @(CLK) read_flag_dly  = #200 read_flag;
+
+always @(posedge CLK) marked_a = A;
+
+assign we  = ~WEN;
+assign cd2 = mem[A] & WEN;	//set write bits to 0, others unchanged
+assign cd4 = D & we;		//set write bits to 0/1, others = 0
+assign cd5 = cd2 | cd4;		//memory content after write
+
+always @(posedge CLK) cdx = {8{1'bx}} & we;    //latch cdx
+
+always @(posedge clk_dly) begin
+  if (write_flag) begin 	//write
+    if (no_st_viol) begin 	//write, no viol
+      mem[A] = cd5;
+    end
+    else begin                 	//write, with viol
+      mem[A] = mem[A] ^ cdx;    //1^x = x
+      qo_reg = qo_reg ^ cdx;
+    end
+  end //write
+  else if (read_flag) begin     //read
+    if (no_st_viol) begin 	//read, no viol
+      qo_reg = mem[marked_a];
+    end
+    else begin                  //read, with viol
+      qo_reg = 8'bx;
+    end
+  end //read
+end
+
+always @(negedge clk_dly) begin         	//invalidate write/read when hold/clk viol
+  if (no_hd_viol == 0 | no_ck_viol == 0) begin
+    if (write_flag_dly) begin
+      if (ntf_twh) begin
+        mem[marked_a] = mem[marked_a] ^ 8'bx; //GWEN can't be used to generate cdx
+        qo_reg        = qo_reg ^ 8'bx;
+      end
+      else begin
+        mem[marked_a] = mem[marked_a] ^ cdx;
+        qo_reg        = qo_reg ^ cdx;
+      end
+    end
+    else if (read_flag_dly) begin
+      qo_reg = 8'bx;
+    end
+
+    #100;
+    ntf_tch  = 0;
+    ntf_tah  = 0;
+    ntf_tdh  = 0;
+    ntf_twh  = 0;
+    ntf_twih = 0;
+
+    ntf_Tcyc  = 0;
+    ntf_Tckh  = 0;
+    ntf_Tckl  = 0;
+  end
+  else begin
+    #100;
+    ntf_tch  = 0;
+    ntf_tah  = 0;
+    ntf_tdh  = 0;
+    ntf_twh  = 0;
+    ntf_twih = 0;
+
+    ntf_Tcyc  = 0;
+    ntf_Tckh  = 0;
+    ntf_Tckl  = 0;
+  end
+end
+
+always @(posedge ntf_tcs or posedge ntf_tas or posedge ntf_tds or
+         posedge ntf_tws or posedge ntf_twis or
+         posedge ntf_tch or posedge ntf_tah or posedge ntf_tdh or
+         posedge ntf_twh or posedge ntf_twih or
+         posedge ntf_Tcyc or posedge ntf_Tckh or posedge ntf_Tckl) begin
+  if (cen_fell) begin
+    #Tdly;
+    if (ntf_tcs)  $display("---- ERROR: CEN setup violation! ----");
+    if (ntf_tas)  $display("---- ERROR: A setup violation! ----");
+    if (ntf_tds)  $display("---- ERROR: D setup violation! ----");
+    if (ntf_tws)  $display("---- ERROR: GWEN setup violation! ----");
+    if (ntf_twis) $display("---- ERROR: WEN setup violation! ----");
+
+    if (ntf_tch)  $display("---- ERROR: CEN hold violation! ----");
+    if (ntf_tah)  $display("---- ERROR: A hold violation! ----");
+    if (ntf_tdh)  $display("---- ERROR: D hold violation! ----");
+    if (ntf_twh)  $display("---- ERROR: GWEN hold violation! ----");
+    if (ntf_twih) $display("---- ERROR: WEN hold violation! ----");
+
+    if (ntf_Tcyc) $display("---- ERROR: CLK period violation! ----");
+    if (ntf_Tckh) $display("---- ERROR: CLK pulse width high violation! ----");
+    if (ntf_Tckl) $display("---- ERROR: CLK pulse width low violation! ----");
+  end
+end
+
+always @(posedge cen_fell) begin	//reset fasle notifiers
+  ntf_tcs  = 0;				//after CEN reset (CEN from 1 to 0)
+  ntf_tas  = 0;
+  ntf_tds  = 0;
+  ntf_tws  = 0;
+  ntf_twis = 0;
+
+  ntf_tch  = 0;
+  ntf_tah  = 0;
+  ntf_tdh  = 0;
+  ntf_twh  = 0;
+  ntf_twih = 0;
+end
+
+always @(negedge clk_dly) begin	//reset setup/hold notifiers
+  #100;
+  ntf_tcs  = 0;
+  ntf_tas  = 0;
+  ntf_tds  = 0;
+  ntf_tws  = 0;
+  ntf_twis = 0;
+
+  ntf_tch  = 0;
+  ntf_tah  = 0;
+  ntf_tdh  = 0;
+  ntf_twh  = 0;
+  ntf_twih = 0;
+end
+
+initial begin			//initialization
+  ntf_Tcyc  = 0;
+  ntf_Tckh  = 0;
+  ntf_Tckl  = 0;
+
+  ntf_tcs  = 0;
+  ntf_tas  = 0;
+  ntf_tds  = 0;
+  ntf_tws  = 0;
+  ntf_twis = 0;
+
+  ntf_tch  = 0;
+  ntf_tah  = 0;
+  ntf_tdh  = 0;
+  ntf_twh  = 0;
+  ntf_twih = 0;
+
+  marked_a = 9'd0;
+
+  qo_reg         = 8'd0;
+  clk_dly        = 0;
+  write_flag_dly = 0;
+  read_flag_dly  = 0;
+  cen_dly        = 0;
+  cen_fell       = 0;
+  cen_not_rst    = 0;
+
+  for(i=0; i<512; i=i+1) begin
+    mem[i] = 8'd0;
+  end
+end
+
+endmodule

--- a/pipeline/hazard.sv
+++ b/pipeline/hazard.sv
@@ -10,11 +10,14 @@ module Hazard (
     input wire [2:0]  result_src_e,
     input wire [4:0]  rd_m,
     input wire        reg_write_m,
+    input wire        read_enable,
+    input wire        read_valid,
     input wire [4:0]  rd_w,
     input wire        reg_write_w,
 
     output logic      stall_f,
     output logic      stall_d,
+    output logic      stall_read,
     output logic      flush_d,
     output logic      flush_e,
     output logic [1:0]forward_a_e,
@@ -42,6 +45,7 @@ always_comb begin
     lwstall = result_src_e[0] & ((rs1_d == rd_e) | (rs2_d == rd_e));
     stall_f = lwstall;
     stall_d = lwstall;
+    stall_read = read_enable & !read_valid;
     flush_d = pc_src_e;
     flush_e = lwstall | pc_src_e;
 end

--- a/pipeline/imemory.sv
+++ b/pipeline/imemory.sv
@@ -6,13 +6,25 @@ module IMemory(
     input  wire          rst,
 
     output logic [31:0]  instr,
-    output logic         valid
+    output logic         valid,
+
+    output logic CEN [0:3],
+    output logic GWEN [0:3],
+    output logic [7:0] WEN [0:3],
+    output logic [8:0] A [0:3],
+    output logic [7:0] D [0:3],
+    input  wire  [7:0] Q [0:3]
 );
 
-logic [7:0] mem [0:4095];
-
-initial begin
-    $readmemh("../test/test.hex", mem);
+always_comb begin
+    for(int i=0;i<4;i++) begin
+        CEN[i] = rst;
+        GWEN[i] = 1;
+        WEN[i]  = {8{1'b1}};
+        A[i] = 9'((pc_fetching + i) >> 2);
+        D[i] = 8'b0;
+    end
+    instr = {Q[3], Q[2], Q[1], Q[0]};
 end
 
 logic        is_first_clk;
@@ -28,7 +40,6 @@ always_ff @(posedge clk) begin
     end
 
     pc_fetched <= pc_fetching;
-    instr <= {mem[pc_fetching+3], mem[pc_fetching+2], mem[pc_fetching+1], mem[pc_fetching]};
 end
 
 always_comb begin

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -6,12 +6,19 @@ module Top(
     output wire tx,
     input wire rx,
 
-    output wire CEN [0:3],
-    output wire GWEN [0:3],
-    output wire [7:0] WEN [0:3],
-    output wire [8:0] A [0:3],
-    output wire [7:0] D [0:3],
-    input  wire  [7:0] Q [0:3]
+    output wire CEN_dmem [0:3],
+    output wire GWEN_dmem [0:3],
+    output wire [7:0] WEN_dmem [0:3],
+    output wire [8:0] A_dmem [0:3],
+    output wire [7:0] D_dmem [0:3],
+    input  wire  [7:0] Q_dmem [0:3],
+
+    output wire CEN_imem [0:3],
+    output wire GWEN_imem [0:3],
+    output wire [7:0] WEN_imem [0:3],
+    output wire [8:0] A_imem [0:3],
+    output wire [7:0] D_imem [0:3],
+    input  wire  [7:0] Q_imem [0:3]
 );
     logic [31: 0] pc;
     wire  [31: 0] instruction;
@@ -105,19 +112,25 @@ module Top(
         .write_enable(dmemory_write_enable),
         .write_mask(write_mask),
         .read_data(dmemory_read_data),
-        .CEN(CEN),
-        .GWEN(GWEN),
-        .WEN(WEN),
-        .A(A),
-        .D(D),
-        .Q(Q)
+        .CEN(CEN_dmem),
+        .GWEN(GWEN_dmem),
+        .WEN(WEN_dmem),
+        .A(A_dmem),
+        .D(D_dmem),
+        .Q(Q_dmem)
     );
     IMemory instruction_memory(
         .clk(clk),
         .pc(pc),
         .rst(rst),
         .instr(instruction),
-        .valid(valid)
+        .valid(valid),
+        .CEN(CEN_imem),
+        .GWEN(GWEN_imem),
+        .WEN(WEN_imem),
+        .A(A_imem),
+        .D(D_imem),
+        .Q(Q_imem)
     );
 
     Uart uart(

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -1,40 +1,57 @@
 `default_nettype none
+`timescale 1ns/1ps
 module Top(
     input  wire clk,
     input  wire rst,
     output wire tx,
-    input wire rx
+    input wire rx,
+
+    output wire CEN [0:3],
+    output wire GWEN [0:3],
+    output wire [7:0] WEN [0:3],
+    output wire [8:0] A [0:3],
+    output wire [7:0] D [0:3],
+    input  wire  [7:0] Q [0:3]
 );
     logic [31: 0] pc;
     wire  [31: 0] instruction;
-
+    
     logic [31: 0] address;
     logic [31: 0] write_data;
     logic [ 3: 0] write_mask;
     logic         write_enable;
+    wire          read_enable;
+    wire          read_valid;
 
     logic [31: 0] read_data;
     logic [31: 0] dmemory_read_data;
     logic [ 7: 0] rx_data;
     logic         outValid;
     wire          valid;
-
-
+    
     logic [15: 0] baud_max;
     logic [ 7: 0] tx_holding;
     logic [ 7: 0] rx_holding;
     logic [ 7: 0] line_status;
 
-    parameter uart_rw_address = 32'h10010000;
-    parameter uart_status_address = 32'h10010005;
-    parameter baud_max_address = 32'h10010100;
-
+    parameter DMEMORY_BASE = 32'h00000000;
+    parameter DMEMORY_SIZE = 32'h10000000;
+    parameter UART_RW_ADDRESS = 32'h10010000;
+    parameter UART_STATUS_ADDRESS = 32'h10010005;
+    parameter BAUD_MAX_ADDRESS = 32'h10010100;
+    
     logic busy;
     logic read_ready;
     logic uart_write_enable;
-    logic read_enable;
+    logic dmemory_write_enable;
+
     always_comb begin
-        uart_write_enable = address == uart_rw_address && write_enable;
+        uart_write_enable = address == UART_RW_ADDRESS && write_enable;
+        if (DMEMORY_BASE <= address && address < DMEMORY_BASE + DMEMORY_SIZE) begin
+            dmemory_write_enable = write_enable;
+        end else begin
+            dmemory_write_enable = 1'b0;
+        end    
     end
     always_ff @(posedge clk) begin
         if (rst) begin
@@ -45,18 +62,17 @@ module Top(
         end
         else begin
             // baud_maxの設定(coreを通してソフトウェアから後で書き換えられるようにしている)
-            if (write_enable && address == baud_max_address) baud_max <= write_data[15:0];
-            if(write_enable) tx_holding <= write_data[7:0];
+            if (write_enable && address == BAUD_MAX_ADDRESS) baud_max <= write_data[15:0];if(write_enable) tx_holding <= write_data[7:0];
             if(outValid) rx_holding <= rx_data;
             line_status <= {1'b0,busy, 5'b0, read_ready};
         end
-    end    
+    end
 
     // read_dataのマルチプレクサ
     always_comb begin
         case(address)
-            uart_rw_address: read_data = {24'b0,rx_holding}; //受信時ならば、rx_holdingを返す
-            uart_status_address: read_data = {24'b0,line_status}; //uart[5]には、busyとread_readyが入っている
+            UART_RW_ADDRESS: read_data = {24'b0,rx_holding}; //受信時ならば、rx_holdingを返す
+            UART_STATUS_ADDRESS: read_data = {24'b0,line_status}; //uart[5]には、busyとread_readyが入っている
             default: read_data = dmemory_read_data; //それ以外の場合は、dmemoryから読み出したデータを返す
         endcase
     end
@@ -68,29 +84,38 @@ module Top(
         .address(address),
         .write_data(write_data),
         .write_enable(write_enable),
+        .read_enable(read_enable),
         .write_mask(write_mask),
 
         .read_data(read_data),
+        .read_valid(read_valid),
 
         .pc(pc),
         .instruction(instruction),
-        .read_enable(read_enable),
         .valid(valid)
     );
   
-    DMemory data_memory(
+    DMemory data_memory_test(
         .clk(clk),
+        .rst(rst),
         .address(address),
+        .read_enable(read_enable),
+        .read_valid(read_valid),
         .write_data(write_data),
-        .write_enable(write_enable && address != uart_rw_address),
+        .write_enable(dmemory_write_enable),
         .write_mask(write_mask),
-        .read_data(dmemory_read_data)
+        .read_data(dmemory_read_data),
+        .CEN(CEN),
+        .GWEN(GWEN),
+        .WEN(WEN),
+        .A(A),
+        .D(D),
+        .Q(Q)
     );
     IMemory instruction_memory(
         .clk(clk),
         .pc(pc),
         .rst(rst),
-
         .instr(instruction),
         .valid(valid)
     );
@@ -107,7 +132,7 @@ module Top(
         .rx_data(rx_data),
         .outValid(outValid),
         .baud_max(baud_max),
-        .negate_read_ready(read_enable && address == uart_rw_address)
+        .negate_read_ready(read_enable && address == UART_RW_ADDRESS)
     );
 
 endmodule

--- a/pipeline/uart.sv
+++ b/pipeline/uart.sv
@@ -16,7 +16,7 @@ module Uart(
     output logic outValid
 ); 
     // baud_clk生成
-    logic [31:0] baud_counter = 32'b0;
+    logic [15:0] baud_counter;
     logic baud_clk = 1'b0;
     logic isRead;
 
@@ -27,7 +27,7 @@ module Uart(
 
     always_ff @(posedge clk) begin
         if (rst) begin
-            baud_counter <= 32'b0;
+            baud_counter <= 16'b0;
             baud_clk <= 1'b0;
             tx_counter <= 0;
             tx_data <= '1;
@@ -41,7 +41,7 @@ module Uart(
             rx_data <= '1;
         end else begin
             if (baud_counter == baud_max-1) begin
-                baud_counter <= 32'b0;
+                baud_counter <= 16'b0;
                 baud_clk <= ~baud_clk;
                 //送信
                 // カウントダウン
@@ -54,7 +54,7 @@ module Uart(
                 if(tx_counter == 5'd10 && busy) begin
                     tx_data <= {1'b1,data,1'b0};
                 end else begin
-                    tx_data <= $signed(tx_data) >>> 1;
+                    tx_data <= 8'($signed(tx_data) >>> 1);
                 end
                 tx <= tx_data[0];
 

--- a/test/store.S
+++ b/test/store.S
@@ -1,7 +1,7 @@
 .section .text
 .global _start
 _start:
-    addi t0,x0,100
+    addi t0,x0,0
     addi t1,x0,-1001
 
     sb t1, 0(t0)
@@ -13,7 +13,7 @@ _start:
     sh x0, 6(t0)
 
     sw t1, 8(t0)
-
+    
     lw s0, 0(t0)
     lw s1, 4(t0)
     lw s2, 8(t0)


### PR DESCRIPTION
# 概要

imemoryとdmemoryをsramに対応した.

## 変更点

### pipeline/Makefile
- gf180mcu_fd_ip_sram__sram512x8m8wm1.svの追加.
### pipeline/core.sv
- read_enable, read_valid, stall_readの追加.
- debug用にinstr_e,instr_m,instr_wの追加
- dmemoryのストール処理を追加
### pipeline/cpu_test.sv
- imemory用のSRAMを8bit*4個, dmemory用のSRAMを8bit*4個, 合計8個のSRAMをインスタンス化.
- imemory用のSRAMにtest.hexから命令を読み込む処理を追加
### pipeline/dmemory.sv
- coreからの入力信号をSRAMへの入力信号に変換して出力
- SRAMの出力(Q[3],...,Q[0])をcoreへの出力(read_data)に変換して出力
### pipeline/hazard.sv
- read_enableとread_validからstall_readを生成 
### pipeline/imemory.sv
- coreからの入力信号をSRAMへの入力信号に変換して出力
- SRAMの出力(Q[3],...,Q[0])をcoreへの出力(instr)に変換して出力
### pipeline/top.sv
- SRAMとimemory, SRAMとdmemory間の入出力信号を接続する.
- parameter名を大文字に変更
### uart.sv
- ビット数を揃える.
### test/store.S
- debugの際, SRAM内部信号mem_0,mem_1, mem_2, mem_3からストアされたことを確認できるように, ベースアドレスを100から0に変更

## 動作確認
store.Sで動作確認を行った.

以下はstore.Sの命令をSRAMへ書き込む際の波形である.
<img width="1024" alt="スクリーンショット 2023-12-10 17 59 18" src="https://github.com/wakuto/our_first_cpu/assets/41273823/cffb0241-167f-4e4b-9ab7-0c4c8c33a4e2">

以下はstore.Sの命令を実行した際の波形である.
<img width="1161" alt="スクリーンショット 2023-12-10 17 59 44" src="https://github.com/wakuto/our_first_cpu/assets/41273823/03b97340-907b-41d2-9cac-9c04256187f9">

どちらも正常な波形が表示されている.