### PR TITLE
Feature/gpio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ cpu
 
 # log
 *.log
+
+# isaの変更をすべて無視
+isa/

--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -1,5 +1,5 @@
-MODULES = alu.sv top.sv core.sv decoder.sv dmemory.sv imemory.sv regfile.sv cpu_test.sv hazard.sv uart.sv gf180mcu_fd_ip_sram__sram512x8m8wm1.sv
-
+MODULES = alu.sv top.sv core.sv decoder.sv dmemory.sv imemory.sv regfile.sv cpu_test.sv hazard.sv uart.sv gpio.sv gf180mcu_fd_ip_sram__sram512x8m8wm1.sv
+TARGET :=
 TARGET_DIR := ../test/isa
 HEX_FILES := $(shell find $(TARGET_DIR) -type f | sort -n | grep -E 'rv32ui-p-.+\.hex')
 
@@ -11,8 +11,8 @@ cpu: $(MODULES)
 program.hex:
 	make -C ../program program.hex
 
-test.hex:
-	make -C ../test test.hex
+test.hex: ../test/$(TARGET).S
+	make -C ../test test.hex TARGET=$(TARGET)
 
 make-hex:
 	make -C ../test hex
@@ -37,6 +37,7 @@ verilator:
 
 clean:
 	rm -rf cpu cpu.vcd
+	rm -rf ../test/test.bin
 
 .PHONY: all run make-hex riscv-test test verilator clean
 

--- a/pipeline/core.sv
+++ b/pipeline/core.sv
@@ -350,7 +350,7 @@ module Core(
             2'b00 : src_a_determined_e = 0;
             2'b01 : src_a_determined_e = rd1_e;
             2'b10 : src_a_determined_e = pc_e;
-            default : srca_e = 32'hBADCAFE;
+            default : src_a_determined_e = 32'hBADCAFE;
         endcase
     end
 

--- a/pipeline/cpu_test.sv
+++ b/pipeline/cpu_test.sv
@@ -49,7 +49,8 @@ module cpu_test();
         .WEN_imem(WEN_imem_read),
         .A_imem(A_imem_read),
         .D_imem(D_imem_read),
-        .Q_imem(Q_imem)
+        .Q_imem(Q_imem),
+        .gpio_in(32'h87654321)
         );
 
     logic [7:0] mem [0:4095];

--- a/pipeline/gpio.sv
+++ b/pipeline/gpio.sv
@@ -6,31 +6,60 @@ module GPIO (
     input  wire [31:0]  address,
     input  wire [31:0]  write_data,
     input  wire         write_enable,
-    output reg [31:0]  read_data,
+    output reg [31:0]   read_data,
     input  wire         read_enable,
 
-    output reg  [31:0]  gpio_out,
-    input  wire [31:0]  gpio_in
+    output reg [31:0]   gpio_out, // GPIOの出力
+    input  wire [31:0]  gpio_in    // GPIOの入力
 );
 
-    parameter GPIO_ADDRESS = 32'ha0000000;
+    parameter GPIO_ADDRESS_IN  = 32'hA0000000;
+    parameter GPIO_ADDRESS_OUT = 32'hA0000100;
 
-    reg [31:0] gpio_register;
+    reg [31:0] gpio_out_reg;
+    reg [31:0] gpio_in_reg;
 
     always_ff @(posedge clk) begin
         if (rst) begin
-            gpio_register <= 32'b0;
-        end else if (write_enable && address == GPIO_ADDRESS) begin
-            gpio_register <= write_data;
+            gpio_out_reg <= 32'h0;
+            gpio_in_reg  <= 32'h0;
+        end else begin
+            if (write_enable) begin
+                if (address == GPIO_ADDRESS_OUT) begin
+                    gpio_out_reg <= write_data;
+                end
+            end
+            if (read_enable) begin
+                if (address == GPIO_ADDRESS_IN) begin
+                    gpio_in_reg <= gpio_in;
+                end 
+            end
         end
     end
+
+    always_comb begin
+        if (read_enable) begin
+            if (address == GPIO_ADDRESS_IN) begin
+                read_data = gpio_in_reg; // GPIO入力を返す
+            end else if (address == GPIO_ADDRESS_OUT) begin
+                read_data = gpio_out_reg; // GPIO出力を返す
+            end else begin
+                read_data = 32'h0; // その他の場合は0
+            end
+        end else begin
+            read_data = 32'h0; // 読み込みが無効な場合は0
+        end
+    end
+
+    // GPIOの出力を外部に接続
     always_ff @(posedge clk) begin
-        if(rst) begin
-            read_data <= 32'b0;
-        end else if (read_enable && address == GPIO_ADDRESS) begin
-            read_data <= gpio_out;
+        if (rst) begin
+            gpio_out <= 32'h0;
+        end else begin
+            gpio_out <= gpio_out_reg;
         end
     end
-    assign gpio_out = gpio_register;
+
 endmodule
+
 `default_nettype wire

--- a/pipeline/gpio.sv
+++ b/pipeline/gpio.sv
@@ -6,7 +6,7 @@ module GPIO (
     input  wire [31:0]  address,
     input  wire [31:0]  write_data,
     input  wire         write_enable,
-    output wire [31:0]  read_data,
+    output reg [31:0]  read_data,
     input  wire         read_enable,
 
     output reg  [31:0]  gpio_out,
@@ -24,15 +24,13 @@ module GPIO (
             gpio_register <= write_data;
         end
     end
-
-    assign read_data = (read_enable && address >= GPIO_ADDRESS) ? gpio_in : 32'h00000000;
-
     always_ff @(posedge clk) begin
-        if (rst) begin
-            gpio_out <= 32'b0;
-        end else begin
-            gpio_out <= gpio_register;
+        if(rst) begin
+            read_data <= 32'b0;
+        end else if (read_enable && address == GPIO_ADDRESS) begin
+            read_data <= gpio_out;
         end
     end
+    assign gpio_out = gpio_register;
 endmodule
 `default_nettype wire

--- a/pipeline/gpio.sv
+++ b/pipeline/gpio.sv
@@ -3,52 +3,28 @@
 module GPIO (
     input  wire         clk,
     input  wire         rst,
-    input  wire [31:0]  address,
     input  wire [31:0]  write_data,
-    input  wire         write_enable,
     output reg [31:0]   read_data,
 
     output reg [31:0]   gpio_out,
     input  wire [31:0]  gpio_in 
 );
-
-    parameter GPIO_ADDRESS_IN  = 32'hA0000000;
-    parameter GPIO_ADDRESS_OUT = 32'hA0000100;
-
     reg [31:0] gpio_out_reg;
-    reg [31:0] gpio_in_reg;
+    reg [31:0] gpio_read_reg;
 
     always_ff @(posedge clk) begin
         if (rst) begin
             gpio_out_reg <= 32'h0;
-            gpio_in_reg  <= 32'h0;
+            gpio_read_reg  <= 32'h0;
         end else begin
-            if (write_enable) begin
-                if (address == GPIO_ADDRESS_OUT) begin
-                    gpio_out_reg <= write_data;
-                end
-            end
-            if (address == GPIO_ADDRESS_IN) begin
-                gpio_in_reg <= gpio_in;
-            end
+            gpio_out_reg <= write_data;
+            gpio_read_reg  <= gpio_in;
         end
     end
 
     always_comb begin
-        if (address == GPIO_ADDRESS_IN) begin
-            read_data = gpio_in_reg;
-        end else if (address == GPIO_ADDRESS_OUT) begin
-            read_data = gpio_out_reg;
-        end else begin
-            read_data = 32'h0;
-        end
-    end
-    always_ff @(posedge clk) begin
-        if (rst) begin
-            gpio_out <= 32'h0;
-        end else begin
-            gpio_out <= gpio_out_reg;
-        end
+        gpio_out = gpio_out_reg;
+        read_data = gpio_read_reg;
     end
 
 endmodule

--- a/pipeline/gpio.sv
+++ b/pipeline/gpio.sv
@@ -13,20 +13,19 @@ module GPIO (
     input  wire [31:0]  gpio_in
 );
 
-    parameter GPIO_BASE = 32'ha0000000;
-    parameter GPIO_SIZE = 32'h00000100;
+    parameter GPIO_ADDRESS = 32'ha0000000;
 
     reg [31:0] gpio_register;
 
     always_ff @(posedge clk) begin
         if (rst) begin
             gpio_register <= 32'b0;
-        end else if (write_enable && (address >= GPIO_BASE && address < GPIO_BASE + GPIO_SIZE)) begin
+        end else if (write_enable && address == GPIO_ADDRESS) begin
             gpio_register <= write_data;
         end
     end
 
-    assign read_data = (read_enable && (address >= GPIO_BASE && address < GPIO_BASE + GPIO_SIZE)) ? gpio_in : 32'h00000000;
+    assign read_data = (read_enable && address >= GPIO_ADDRESS) ? gpio_in : 32'h00000000;
 
     always_ff @(posedge clk) begin
         if (rst) begin

--- a/pipeline/gpio.sv
+++ b/pipeline/gpio.sv
@@ -1,0 +1,39 @@
+`default_nettype none
+
+module GPIO (
+    input  wire         clk,
+    input  wire         rst,
+    input  wire [31:0]  address,
+    input  wire [31:0]  write_data,
+    input  wire         write_enable,
+    output wire [31:0]  read_data,
+    input  wire         read_enable,
+
+    output reg  [31:0]  gpio_out,
+    input  wire [31:0]  gpio_in
+);
+
+    parameter GPIO_BASE = 32'ha0000000;
+    parameter GPIO_SIZE = 32'h00000100;
+
+    reg [31:0] gpio_register;
+
+    always_ff @(posedge clk) begin
+        if (rst) begin
+            gpio_register <= 32'b0;
+        end else if (write_enable && (address >= GPIO_BASE && address < GPIO_BASE + GPIO_SIZE)) begin
+            gpio_register <= write_data;
+        end
+    end
+
+    assign read_data = (read_enable && (address >= GPIO_BASE && address < GPIO_BASE + GPIO_SIZE)) ? gpio_in : 32'h00000000;
+
+    always_ff @(posedge clk) begin
+        if (rst) begin
+            gpio_out <= 32'b0;
+        end else begin
+            gpio_out <= gpio_register;
+        end
+    end
+endmodule
+`default_nettype wire

--- a/pipeline/gpio.sv
+++ b/pipeline/gpio.sv
@@ -7,10 +7,9 @@ module GPIO (
     input  wire [31:0]  write_data,
     input  wire         write_enable,
     output reg [31:0]   read_data,
-    input  wire         read_enable,
 
-    output reg [31:0]   gpio_out, // GPIOの出力
-    input  wire [31:0]  gpio_in    // GPIOの入力
+    output reg [31:0]   gpio_out,
+    input  wire [31:0]  gpio_in 
 );
 
     parameter GPIO_ADDRESS_IN  = 32'hA0000000;
@@ -29,29 +28,21 @@ module GPIO (
                     gpio_out_reg <= write_data;
                 end
             end
-            if (read_enable) begin
-                if (address == GPIO_ADDRESS_IN) begin
-                    gpio_in_reg <= gpio_in;
-                end 
+            if (address == GPIO_ADDRESS_IN) begin
+                gpio_in_reg <= gpio_in;
             end
         end
     end
 
     always_comb begin
-        if (read_enable) begin
-            if (address == GPIO_ADDRESS_IN) begin
-                read_data = gpio_in_reg; // GPIO入力を返す
-            end else if (address == GPIO_ADDRESS_OUT) begin
-                read_data = gpio_out_reg; // GPIO出力を返す
-            end else begin
-                read_data = 32'h0; // その他の場合は0
-            end
+        if (address == GPIO_ADDRESS_IN) begin
+            read_data = gpio_in_reg;
+        end else if (address == GPIO_ADDRESS_OUT) begin
+            read_data = gpio_out_reg;
         end else begin
-            read_data = 32'h0; // 読み込みが無効な場合は0
+            read_data = 32'h0;
         end
     end
-
-    // GPIOの出力を外部に接続
     always_ff @(posedge clk) begin
         if (rst) begin
             gpio_out <= 32'h0;

--- a/pipeline/gpio.sv
+++ b/pipeline/gpio.sv
@@ -5,6 +5,7 @@ module GPIO (
     input  wire         rst,
     input  wire [31:0]  write_data,
     output reg [31:0]   read_data,
+    input wire write_enable,
 
     output reg [31:0]   gpio_out,
     input  wire [31:0]  gpio_in 
@@ -14,11 +15,17 @@ module GPIO (
 
     always_ff @(posedge clk) begin
         if (rst) begin
-            gpio_out_reg <= 32'h0;
             gpio_read_reg  <= 32'h0;
         end else begin
-            gpio_out_reg <= write_data;
             gpio_read_reg  <= gpio_in;
+        end
+    end
+
+    always_ff @(posedge clk) begin
+        if (rst) begin
+            gpio_out_reg <= 32'h0;
+        end else if (write_enable) begin
+            gpio_out_reg <= write_data;
         end
     end
 

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -61,6 +61,7 @@ module Top(
     logic dmemory_write_enable;
     logic [31:0] gpio_read_data;
     logic [31: 0] gpio_write_data;
+    logic gpio_write_enable;
 
 
     always_comb begin
@@ -105,11 +106,13 @@ module Top(
     end
 
     // write_dataのマルチプレクサ
-    always_ff @(posedge clk) begin
-        if(rst) begin
-            gpio_write_data = 32'h0;
-        end else if(address == GPIO_ADDRESS_OUT && write_enable) begin
+    always_comb begin
+        if(address == GPIO_ADDRESS_OUT) begin
             gpio_write_data = write_data;
+            gpio_write_enable = write_enable;
+        end else begin
+            gpio_write_data = 32'h0;
+            gpio_write_enable = 1'b0;
         end
     end
 
@@ -183,9 +186,9 @@ module Top(
         .write_data(gpio_write_data),
         .read_data(gpio_read_data),
         .gpio_out(gpio_out),
-        .gpio_in(gpio_in)
+        .gpio_in(gpio_in),
+        .write_enable(write_enable)
     );
-
 
 endmodule
 `default_nettype wire

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -49,8 +49,7 @@ module Top(
     parameter IMEMORY_SIZE = 32'h00000800;
     parameter DMEMORY_BASE = 32'h90000000;
     parameter DMEMORY_SIZE = 32'h00000800;
-    parameter GPIO_BASE    = 32'ha0000000;
-    parameter GPIO_SIZE    = 32'h00000010;
+    parameter GPIO_ADDRESS   = 32'ha0000000;
     parameter UART_RW_ADDRESS = 32'h10010000;
     parameter UART_STATUS_ADDRESS = 32'h10010005;
     parameter BAUD_MAX_ADDRESS = 32'h10010100;
@@ -89,7 +88,7 @@ module Top(
         case(address)
             UART_RW_ADDRESS: read_data = {24'b0,rx_holding}; //受信時ならば、rx_holdingを返す
             UART_STATUS_ADDRESS: read_data = {24'b0,line_status}; //uart[5]には、busyとread_readyが入っている
-            GPIO_BASE: read_data = gpio_read_data; // GPIO read
+            GPIO_ADDRESS: read_data = gpio_read_data; // GPIO read
             default: read_data = dmemory_read_data; //それ以外の場合は、dmemoryから読み出したデータを返す
         endcase
 
@@ -171,7 +170,7 @@ module Top(
         .address(address),
         .write_data(write_data),
         .write_enable(write_enable),
-        .read_data(gpio_read_data),  // 修正: gpio_read_dataを接続
+        .read_data(gpio_read_data),
         .read_enable(read_enable),
         .gpio_out(gpio_out),
         .gpio_in(gpio_in)

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -59,7 +59,9 @@ module Top(
     logic read_ready;
     logic uart_write_enable;
     logic dmemory_write_enable;
-    logic [31:0] gpio_read_data;  // gpio_read_dataの宣言
+    logic [31:0] gpio_read_data;
+    logic [31: 0] gpio_write_data;
+
 
     always_comb begin
         uart_write_enable = address == UART_RW_ADDRESS && write_enable;
@@ -99,6 +101,15 @@ module Top(
             instruction = instruction_raw;
         end else begin
             instruction = 0;
+        end
+    end
+
+    // write_dataのマルチプレクサ
+    always_ff @(posedge clk) begin
+        if(rst) begin
+            gpio_write_data = 32'h0;
+        end else if(address == GPIO_ADDRESS_OUT && write_enable) begin
+            gpio_write_data = write_data;
         end
     end
 
@@ -169,9 +180,7 @@ module Top(
     GPIO gpio(
         .clk(clk),
         .rst(rst),
-        .address(address),
-        .write_data(write_data),
-        .write_enable(write_enable),
+        .write_data(gpio_write_data),
         .read_data(gpio_read_data),
         .gpio_out(gpio_out),
         .gpio_in(gpio_in)

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -90,6 +90,7 @@ module Top(
             UART_RW_ADDRESS: read_data = {24'b0,rx_holding}; //受信時ならば、rx_holdingを返す
             UART_STATUS_ADDRESS: read_data = {24'b0,line_status}; //uart[5]には、busyとread_readyが入っている
             GPIO_ADDRESS_IN: read_data = gpio_read_data; // GPIO read
+            GPIO_ADDRESS_OUT: read_data = gpio_out; // GPIO write
             default: read_data = dmemory_read_data; //それ以外の場合は、dmemoryから読み出したデータを返す
         endcase
 
@@ -172,7 +173,6 @@ module Top(
         .write_data(write_data),
         .write_enable(write_enable),
         .read_data(gpio_read_data),
-        .read_enable(read_enable),
         .gpio_out(gpio_out),
         .gpio_in(gpio_in)
     );

--- a/pipeline/top.sv
+++ b/pipeline/top.sv
@@ -49,7 +49,8 @@ module Top(
     parameter IMEMORY_SIZE = 32'h00000800;
     parameter DMEMORY_BASE = 32'h90000000;
     parameter DMEMORY_SIZE = 32'h00000800;
-    parameter GPIO_ADDRESS   = 32'ha0000000;
+    parameter GPIO_ADDRESS_IN   = 32'ha0000000;
+    parameter GPIO_ADDRESS_OUT  = 32'ha0000100;
     parameter UART_RW_ADDRESS = 32'h10010000;
     parameter UART_STATUS_ADDRESS = 32'h10010005;
     parameter BAUD_MAX_ADDRESS = 32'h10010100;
@@ -88,7 +89,7 @@ module Top(
         case(address)
             UART_RW_ADDRESS: read_data = {24'b0,rx_holding}; //受信時ならば、rx_holdingを返す
             UART_STATUS_ADDRESS: read_data = {24'b0,line_status}; //uart[5]には、busyとread_readyが入っている
-            GPIO_ADDRESS: read_data = gpio_read_data; // GPIO read
+            GPIO_ADDRESS_IN: read_data = gpio_read_data; // GPIO read
             default: read_data = dmemory_read_data; //それ以外の場合は、dmemoryから読み出したデータを返す
         endcase
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,4 @@
-PREFIX=riscv32-unknown-elf-
+PREFIX=riscv64-unknown-elf-
 TARGET :=
 TARGET_DIR := ./isa
 PATTERN := ^rv32ui-p-[a-z]+$
@@ -9,12 +9,12 @@ BIN_FILES := $(shell find $(TARGET_DIR) -type f | sort -n | grep -E 'rv32ui-p-.+
 all: test.bin
 
 test.bin: ${TARGET}.S link.ld
-	$(PREFIX)as ./${TARGET}.S -c -o ${TARGET}.o
-	$(PREFIX)ld ./${TARGET}.o -Tlink.ld -o ./${TARGET}.elf
+	$(PREFIX)as -march=rv32i -mabi=ilp32 ./${TARGET}.S -c -o ${TARGET}.o
+	$(PREFIX)ld -b elf32-littleriscv ./${TARGET}.o -Tlink.ld -o ./${TARGET}.elf
 	$(PREFIX)objcopy -O binary ./${TARGET}.elf ./test.bin
 
 test.hex: test.bin
-	od -t x1 -A n -w1 -v ./test.bin > ./test.hex
+	hexdump -v -e '1/1 "%02x\n"' ./test.bin > ./test.hex
 
 bin: link.ld
 	@for name in $(FILES); do\
@@ -23,7 +23,7 @@ bin: link.ld
 
 hex: bin
 	@for name in $(FILES); do\
-		od -t x1 -A n -w1 -v $$name.bin > $$name.hex;\
+		od -t x1 -A n -v $$name.bin > $$name.hex;\
 	done
 
 dump:

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,7 @@ bin: link.ld
 
 hex: bin
 	@for name in $(FILES); do\
-		od -t x1 -A n -v $$name.bin > $$name.hex;\
+		hexdump -v -e '1/1 "%02x\n"' $$name.bin > $$name.hex
 	done
 
 dump:

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,7 @@ bin: link.ld
 
 hex: bin
 	@for name in $(FILES); do\
-		hexdump -v -e '1/1 "%02x\n"' $$name.bin > $$name.hex
+		hexdump -v -e '1/1 "%02x\n"' $$name.bin > $$name.hex;\
 	done
 
 dump:

--- a/test/gpio.S
+++ b/test/gpio.S
@@ -1,17 +1,19 @@
     .section .data
-GPIO_BASE:    .word 0xA0000000    # GPIOベースアドレス
+GPIO_ADDRESS_IN:    .word 0xA0000000
+GPIO_ADDRESS_OUT:   .word 0xA0000100
     .section .text
     .global _start
 
 _start:
-    # GPIO出力値を書き込む (0x54321 を GPIO に書き込む)
-    la      t0, GPIO_BASE          # GPIOベースアドレスをt0にロード
-    li      t1, 0x87654321         # 書き込む値をt1にロード
-    sw      t1, 0(t0)              # GPIOベースアドレスに書き込む
+    # GPIO出力値を書き込む (0x87654321 を GPIO に書き込む)
+    la      t0, GPIO_ADDRESS_OUT          # GPIOのOUTPUTアドレスをt0にロード
+    li      t1, 0x87654321                # 書き込む値をt1にロード
+    sw      t1, 0(t0)                     # GPIOのOUTPUTに値を書き込む
 
     # GPIO入力値を読み取る
-    lw      t2, 0(t0)              # GPIOの入力値をt2にロード
+    la      t0, GPIO_ADDRESS_IN           # GPIOのINPUTアドレスをt0にロード
+    sw      t1, 0(t0)                     # GPIOのINPUTに値を書き込む
+    lw      s0, 0(t0)                     # GPIOのINPUTから値を読み取りs0にロード
 
 .end:
     beq x0, x0, .end
-

--- a/test/gpio.S
+++ b/test/gpio.S
@@ -1,19 +1,13 @@
-    .section .data
-GPIO_ADDRESS_IN:    .word 0xA0000000
-GPIO_ADDRESS_OUT:   .word 0xA0000100
-    .section .text
+.equ GPIO_ADDRESS_IN, 0xA0000000
+.equ GPIO_ADDRESS_OUT, 0xA0000100
     .global _start
 
 _start:
-    # GPIO出力値を書き込む (0x87654321 を GPIO に書き込む)
-    la      t0, GPIO_ADDRESS_OUT          # GPIOのOUTPUTアドレスをt0にロード
     li      t1, 0x87654321                # 書き込む値をt1にロード
-    sw      t1, 0(t0)                     # GPIOのOUTPUTに値を書き込む
-
-    # GPIO入力値を読み取る
-    la      t0, GPIO_ADDRESS_IN           # GPIOのINPUTアドレスをt0にロード
-    sw      t1, 0(t0)                     # GPIOのINPUTに値を書き込む
-    lw      s0, 0(t0)                     # GPIOのINPUTから値を読み取りs0にロード
-
+    li      t0, GPIO_ADDRESS_OUT          # GPIOのOUTPUTアドレスをt0にロード
+    sw      t1, 0(t0)                     # GPIOのOUTPUTアドレスにt1をストア
+    lw      s0, 0(t0)                     # GPIOのOUTPUTアドレスから値を読み取りs0にロード
+    li      t0, GPIO_ADDRESS_IN           # GPIOのINPUTアドレスをt0にロード
+    sw      t1, 0(t0)                     # GPIOのINPUTアドレスにt1をストア
 .end:
     beq x0, x0, .end

--- a/test/gpio.S
+++ b/test/gpio.S
@@ -4,10 +4,11 @@
 
 _start:
     li      t1, 0x87654321                # 書き込む値をt1にロード
-    li      t0, GPIO_ADDRESS_OUT          # GPIOのOUTPUTアドレスをt0にロード
-    sw      t1, 0(t0)                     # GPIOのOUTPUTアドレスにt1をストア
-    lw      s0, 0(t0)                     # GPIOのOUTPUTアドレスから値を読み取りs0にロード
-    li      t0, GPIO_ADDRESS_IN           # GPIOのINPUTアドレスをt0にロード
-    sw      t1, 0(t0)                     # GPIOのINPUTアドレスにt1をストア
+    li      t0, GPIO_ADDRESS_OUT          
+    sw      t1, 0(t0)                     
+    lw      s0, 0(t0)         
+            
+    li      t0, GPIO_ADDRESS_IN
+    lw      s1, 0(t0)
 .end:
     beq x0, x0, .end

--- a/test/gpio.S
+++ b/test/gpio.S
@@ -1,11 +1,11 @@
     .section .data
-GPIO_BASE:    .word 0xA0000000    # GPIOベースアドレス
+GPIO_ADDRESS:    .word 0xA0000000    # GPIOベースアドレス
     .section .text
     .global _start
 
 _start:
     # GPIO出力値を書き込む (0x54321 を GPIO に書き込む)
-    la      t0, GPIO_BASE
+    la      t0, GPIO_ADDRESS
     li      t1, 0x87654321         # 書き込む値をt1にロード
     sw      t1, 0(t0)              # GPIOベースアドレスに書き込む
 

--- a/test/gpio.S
+++ b/test/gpio.S
@@ -1,11 +1,11 @@
     .section .data
-GPIO_ADDRESS:    .word 0xA0000000    # GPIOベースアドレス
+GPIO_BASE:    .word 0xA0000000    # GPIOベースアドレス
     .section .text
     .global _start
 
 _start:
     # GPIO出力値を書き込む (0x54321 を GPIO に書き込む)
-    la      t0, GPIO_ADDRESS
+    la      t0, GPIO_BASE          # GPIOベースアドレスをt0にロード
     li      t1, 0x87654321         # 書き込む値をt1にロード
     sw      t1, 0(t0)              # GPIOベースアドレスに書き込む
 

--- a/test/gpio.S
+++ b/test/gpio.S
@@ -1,0 +1,17 @@
+    .section .data
+GPIO_BASE:    .word 0xA0000000    # GPIOベースアドレス
+    .section .text
+    .global _start
+
+_start:
+    # GPIO出力値を書き込む (0x54321 を GPIO に書き込む)
+    la      t0, GPIO_BASE
+    li      t1, 0x87654321         # 書き込む値をt1にロード
+    sw      t1, 0(t0)              # GPIOベースアドレスに書き込む
+
+    # GPIO入力値を読み取る
+    lw      t2, 0(t0)              # GPIOの入力値をt2にロード
+
+.end:
+    beq x0, x0, .end
+


### PR DESCRIPTION
## 概要
Makefileのmake testがpipelineから実行できるように変更した。
PREFIXをriscv64-unknown-elf-に変更した上で、32bitのRISCVアーキテクチャとして実行されるように調整した。
さらに、　32bitのGPIOを追加し、アドレスチェック機構をtop.svに移した。各モジュールの関係は下図の通りである。（スイッチとLEDを図示しているせいでわかりにくいが、実際には32bit単位で入出力を行っている。
![IMG_0198](https://github.com/user-attachments/assets/9fa57c92-54f2-4b6d-be48-5020d9461440)
## 変更点

### pipeline/cpu_test.sv
- gpio_inに0x87654321を出力

### pipeline/Makefile
- MODULESにgpio.svを追加
- 引数のTARGETを追加
- test/MakefileにTARGETを渡して実行
- clean時にtest.binを削除することで、 test/Makefileのtest.binに対する処理がスキップされないようにした

### pipeline/core.sv
- src_a_determined_eに対するcase文の修正

### pipeline/gpio.sv
- gpio_inをtopから受け取り、gpio_read_dataに出力
- gpio_write_dataをtopから受け取り、gpio_outに出力

### pipeline/top.sv
- gpio モジュールとの接続
- parameter GPIO_ADDRESS_IN   = 32'ha0000000;
- parameter GPIO_ADDRESS_OUT  = 32'ha0000100;
- gpioのアドレスチェック回路を実装

### test/gpio.S
- gpioに対するテストコードを追加

## 動作確認
### テストの手順
```
make clean
make test TARGET=gpio
```
### テスト用アセンブリ
```
.equ GPIO_ADDRESS_IN, 0xA0000000
.equ GPIO_ADDRESS_OUT, 0xA0000100
    .global _start

_start:
    li      t1, 0x87654321                # 書き込む値を6番にロード
    li      t0, GPIO_ADDRESS_OUT   # gpio出力アドレスを5番にロード   
    sw      t1, 0(t0)                     #gpioのoutputに6番を書き込む
    lw      s0, 0(t0)         # gpio_outの値を8番にロード
            
    li      t0, GPIO_ADDRESS_IN　# gpioの入力アドレスを5番にロード
    lw      s1, 0(t0) # gpio_inの値を9番にロード
.end:
    beq x0, x0, .end
```
### 出力結果の波形
<img width="1123" alt="スクリーンショット 2024-10-31 12 28 43" src="https://github.com/user-attachments/assets/5bb6116e-7f40-4aa8-a663-6d32786e2a02">
